### PR TITLE
(refactor): remove stuff handled by additonal headers

### DIFF
--- a/packages/axios/int-test/HttpCommunication.test.ts
+++ b/packages/axios/int-test/HttpCommunication.test.ts
@@ -4,21 +4,33 @@ import { AxiosClient, AxiosClientError } from "../src";
 
 describe("HTTP Communication Tests", function () {
   const BASE_URL = "https://services.odata.org/TripPinRESTierService/(S(xxxsujx4iqjss1vkeighyks6))";
+  const DEFAULT_HEADERS = { Accept: "application/json", "Content-Type": "application/json" };
 
-  const REAL_CLIENT = new AxiosClient();
+  const REAL_CLIENT = new AxiosClient({ headers: DEFAULT_HEADERS });
 
   test("Simple Get", async () => {
     const url = BASE_URL + "/People('russellwhyte')";
     const response = await REAL_CLIENT.get<ODataCollectionResponseV4<any>>(url);
+    const { date, ...headers } = response.headers;
     expect(response).toMatchObject({
       status: 200,
       statusText: "OK",
-      headers: {
-        "cache-control": "no-cache",
-        "content-type": "application/json; odata.metadata=minimal",
-        "odata-version": "4.0",
-        pragma: "no-cache",
-      },
+    });
+    expect(headers).toStrictEqual({
+      "content-length": "445",
+      "content-type": "application/json; odata.metadata=minimal",
+      "cache-control": "no-cache",
+      // "content-encoding": "gzip",
+      expires: "-1",
+      pragma: "no-cache",
+      "odata-version": "4.0",
+      server: "Microsoft-IIS/10.0",
+      vary: "Accept-Encoding",
+      "x-aspnet-version": "4.0.30319",
+      "x-powered-by": "ASP.NET",
+
+      // axios specials
+      connection: "close",
     });
     expect(response.data).toMatchObject({
       FirstName: "Russell",

--- a/packages/axios/src/AxiosClient.ts
+++ b/packages/axios/src/AxiosClient.ts
@@ -9,7 +9,7 @@ import axios, {
 } from "axios";
 
 import { AxiosClientError } from "./AxiosClientError";
-import { AxiosRequestConfig, getDefaultConfig, mergeConfig } from "./AxiosRequestConfig";
+import { AxiosRequestConfig, mergeConfig } from "./AxiosRequestConfig";
 
 export interface ClientOptions extends BaseHttpClientOptions {}
 
@@ -29,7 +29,7 @@ export class AxiosClient extends BaseHttpClient<AxiosRequestConfig> {
 
   constructor(config?: AxiosRequestConfig, private clientOptions?: ClientOptions) {
     super(clientOptions);
-    this.client = axios.create(getDefaultConfig(config));
+    this.client = axios.create(config);
   }
 
   protected addHeaderToRequestConfig(

--- a/packages/axios/src/AxiosRequestConfig.ts
+++ b/packages/axios/src/AxiosRequestConfig.ts
@@ -9,14 +9,6 @@ export interface InternalRequestConfig extends Omit<OriginalRequestConfig, "head
   headers?: Record<string, string>;
 }
 
-const DEFAULT_CONFIG: InternalRequestConfig = {
-  headers: { Accept: "application/json", "Content-Type": "application/json" },
-};
-
-export function getDefaultConfig(config?: AxiosRequestConfig | undefined): CreateAxiosDefaults {
-  return mergeConfig(DEFAULT_CONFIG, config as InternalRequestConfig) as CreateAxiosDefaults;
-}
-
 export function mergeConfig(): undefined;
 export function mergeConfig(...configs: Array<InternalRequestConfig | undefined>): InternalRequestConfig;
 export function mergeConfig(...configs: Array<InternalRequestConfig | undefined>) {

--- a/packages/axios/test/AxiosRequestConfig.test.ts
+++ b/packages/axios/test/AxiosRequestConfig.test.ts
@@ -1,10 +1,6 @@
-import { getDefaultConfig, mergeConfig } from "../src/AxiosRequestConfig";
+import { mergeConfig } from "../src/AxiosRequestConfig";
 
 describe("FetchRequestConfig Tests", function () {
-  test("get default config", async () => {
-    expect(getDefaultConfig().headers).toBeDefined();
-  });
-
   test("merge config", async () => {
     expect(mergeConfig()).toBeUndefined();
   });

--- a/packages/axios/test/FailureHandling.test.ts
+++ b/packages/axios/test/FailureHandling.test.ts
@@ -24,7 +24,7 @@ describe("Failure Handling Tests", function () {
   } = {};
 
   // @ts-ignore
-  axios.create = jest.fn(({ headers, ...defaultConfig }: CreateAxiosDefaults) => ({
+  axios.create = jest.fn(({ headers, ...defaultConfig }: CreateAxiosDefaults = {}) => ({
     request: ({ headers: reqHeaders, ...config }: OriginalRequestConfig): Promise<Partial<AxiosResponse>> => {
       requestConfig = {
         headers: {

--- a/packages/fetch/int-test/HttpCommunication.test.ts
+++ b/packages/fetch/int-test/HttpCommunication.test.ts
@@ -3,13 +3,15 @@ import { ODataCollectionResponseV4, ODataModelResponseV4 } from "@odata2ts/odata
 import { FetchClient, FetchClientError } from "../src";
 
 describe("HTTP Communication Tests", function () {
-  const BASE_URL = "https://services.odata.org/TripPinRESTierService/(S(xxxsujx4iqjss1vkeighyks6))";
+  const BASE_URL = "https://services.odata.org/TripPinRESTierService/(S(xxxsujx4iqjss1vkeighyks7))";
+  const DEFAULT_HEADERS = { Accept: "application/json", "Content-Type": "application/json" };
 
-  const REAL_CLIENT = new FetchClient();
+  const REAL_CLIENT = new FetchClient({ headers: DEFAULT_HEADERS });
 
   test("Simple Get", async () => {
     const url = BASE_URL + "/People('russellwhyte')";
     const response = await REAL_CLIENT.get<ODataCollectionResponseV4<any>>(url);
+    const { date, ...headers } = response.headers;
     expect(response).toMatchObject({
       status: 200,
       statusText: "OK",
@@ -19,6 +21,19 @@ describe("HTTP Communication Tests", function () {
         "odata-version": "4.0",
         pragma: "no-cache",
       },
+    });
+    expect(headers).toStrictEqual({
+      "content-length": "445",
+      "content-type": "application/json; odata.metadata=minimal",
+      "cache-control": "no-cache",
+      "content-encoding": "gzip",
+      expires: "-1",
+      pragma: "no-cache",
+      "odata-version": "4.0",
+      server: "Microsoft-IIS/10.0",
+      vary: "Accept-Encoding",
+      "x-aspnet-version": "4.0.30319",
+      "x-powered-by": "ASP.NET",
     });
     expect(response.data).toMatchObject({
       FirstName: "Russell",

--- a/packages/fetch/src/FetchClient.ts
+++ b/packages/fetch/src/FetchClient.ts
@@ -19,7 +19,7 @@ function buildErrorMessage(prefix: string, error: any) {
 export class FetchClient extends BaseHttpClient<FetchRequestConfig> {
   protected readonly config: RequestInit;
 
-  constructor(config?: FetchRequestConfig, private clientOptions?: ClientOptions) {
+  constructor(config?: FetchRequestConfig, clientOptions?: ClientOptions) {
     super(clientOptions);
     this.config = getDefaultConfig(config);
   }

--- a/packages/fetch/src/FetchRequestConfig.ts
+++ b/packages/fetch/src/FetchRequestConfig.ts
@@ -1,6 +1,6 @@
 const DEFAULT_CONFIG: RequestInit = {
-  headers: { Accept: "application/json", "Content-Type": "application/json" },
-  cache: "no-cache",
+  // headers: { Accept: "application/json", "Content-Type": "application/json" },
+  cache: "no-store",
 };
 
 /**

--- a/packages/fetch/test/FetchODataClient.test.ts
+++ b/packages/fetch/test/FetchODataClient.test.ts
@@ -7,9 +7,7 @@ describe("FetchClient Tests", function () {
   let simulateNoContent: boolean = false;
 
   const DEFAULT_URL = "TEST/hi";
-  const JSON_VALUE = "application/json";
-  const DEFAULT_REQUEST_CONFIG = { method: "GET", cache: "no-cache" };
-  const DEFAULT_HEADERS = { accept: JSON_VALUE, "content-type": JSON_VALUE };
+  const DEFAULT_REQUEST_CONFIG = { method: "GET", cache: "no-store" };
 
   // Mocking fetch
   // @ts-ignore: more simplistic parameters and returning different stuff
@@ -67,7 +65,7 @@ describe("FetchClient Tests", function () {
 
     expect(requestUrl).toBe(DEFAULT_URL);
     expect(getBaseRequestConfig()).toStrictEqual(DEFAULT_REQUEST_CONFIG);
-    expect(getRequestHeaderRecords()).toStrictEqual(DEFAULT_HEADERS);
+    expect(getRequestHeaderRecords()).toStrictEqual({});
   });
 
   test("invalid url", async () => {
@@ -93,7 +91,7 @@ describe("FetchClient Tests", function () {
     await fetchClient.get("", { headers, ...config });
 
     expect(getBaseRequestConfig()).toStrictEqual({ ...DEFAULT_REQUEST_CONFIG, ...config });
-    expect(getRequestHeaderRecords()).toStrictEqual({ ...DEFAULT_HEADERS, ...headers });
+    expect(getRequestHeaderRecords()).toStrictEqual(headers);
   });
 
   test("using additional headers", async () => {
@@ -101,7 +99,7 @@ describe("FetchClient Tests", function () {
 
     await fetchClient.get("", undefined, headers);
 
-    expect(getRequestHeaderRecords()).toStrictEqual({ ...DEFAULT_HEADERS, ...headers });
+    expect(getRequestHeaderRecords()).toStrictEqual(headers);
   });
 
   test("request config overrides everything", async () => {
@@ -129,7 +127,7 @@ describe("FetchClient Tests", function () {
 
     expect(requestUrl).toBe(DEFAULT_URL);
     expect(getBaseRequestConfig()).toStrictEqual(getDefaultBaseConfigForMethod("POST"));
-    expect(getRequestHeaderRecords()).toStrictEqual(DEFAULT_HEADERS);
+    expect(getRequestHeaderRecords()).toStrictEqual({});
   });
 
   test("post request with different data", async () => {
@@ -149,7 +147,6 @@ describe("FetchClient Tests", function () {
 
     expect(requestUrl).toBe(DEFAULT_URL);
     expect(getBaseRequestConfig()).toStrictEqual(getDefaultBaseConfigForMethod("PUT"));
-    expect(getRequestHeaderRecords()).toStrictEqual(DEFAULT_HEADERS);
   });
 
   test("patch request", async () => {
@@ -157,15 +154,6 @@ describe("FetchClient Tests", function () {
 
     expect(requestUrl).toBe(DEFAULT_URL);
     expect(getBaseRequestConfig()).toStrictEqual(getDefaultBaseConfigForMethod("PATCH"));
-    expect(getRequestHeaderRecords()).toStrictEqual(DEFAULT_HEADERS);
-  });
-
-  test("merge request", async () => {
-    await fetchClient.merge(DEFAULT_URL, {});
-
-    expect(requestUrl).toBe(DEFAULT_URL);
-    expect(getBaseRequestConfig()).toStrictEqual(getDefaultBaseConfigForMethod("POST"));
-    expect(getRequestHeaderRecords()).toStrictEqual({ ...DEFAULT_HEADERS, "x-http-method": "MERGE" });
   });
 
   test("delete request", async () => {
@@ -173,7 +161,6 @@ describe("FetchClient Tests", function () {
 
     expect(requestUrl).toBe(DEFAULT_URL);
     expect(getBaseRequestConfig()).toStrictEqual({ ...DEFAULT_REQUEST_CONFIG, method: "DELETE" });
-    expect(getRequestHeaderRecords()).toStrictEqual(DEFAULT_HEADERS);
   });
 
   test("simulate 204 no content", async () => {

--- a/packages/http-client-api/src/ODataHttpClient.ts
+++ b/packages/http-client-api/src/ODataHttpClient.ts
@@ -60,28 +60,6 @@ export interface ODataHttpClient<RequestConfig = any> {
   ): ODataResponse<ResponseModel>;
 
   /**
-   * OData V2 only feature.
-   * Historically, PATCH method was not part of the official HTTP spec, when V1 & V2 were specified;
-   * but use of PATCH was already envisioned {@link https://www.odata.org/documentation/odata-version-2-0/operations/}.
-   * V3 and all following versions, specify use of PATCH method.
-   *
-   * If implemented, this method wil be used instead of patch to partially update models.
-   * Use case: You want to reuse this client and one server can only handle MERGE,
-   * but not PATCH http requests.
-   *
-   * @param url
-   * @param data
-   * @param requestConfig
-   * @param additionalHeaders
-   */
-  merge?<ResponseModel>(
-    url: string,
-    data: any,
-    requestConfig?: RequestConfig,
-    additionalHeaders?: Record<string, string>
-  ): ODataResponse<ResponseModel>;
-
-  /**
    * Delete a model or collection.
    *
    * @param url
@@ -89,14 +67,4 @@ export interface ODataHttpClient<RequestConfig = any> {
    * @param additionalHeaders
    */
   delete(url: string, requestConfig?: RequestConfig, additionalHeaders?: Record<string, string>): ODataResponse<void>;
-
-  /**
-   * Get `Edm.Int64` and `Edm.Decimal` types as string instead of number to prevent precision loss.
-   * Only applies to V4 services.
-   *
-   * Set by odata2ts.
-   *
-   * @param enabled
-   */
-  retrieveBigNumbersAsString(enabled: boolean): void;
 }

--- a/packages/http-client-base/src/BaseHttpClient.ts
+++ b/packages/http-client-base/src/BaseHttpClient.ts
@@ -17,9 +17,6 @@ export interface BaseHttpClientOptions {
 }
 
 export const DEFAULT_CSRF_TOKEN_KEY = "x-csrf-token";
-const BIG_NUMBER_FORMAT = "application/json;IEEE754Compatible=true";
-export const BIG_NUMBERS_HEADERS = { Accept: BIG_NUMBER_FORMAT, "Content-Type": BIG_NUMBER_FORMAT };
-export const MERGE_HEADERS = { "X-Http-Method": "MERGE" };
 
 const EDIT_METHODS = ["POST", "PUT", "PATCH", "DELETE"];
 const FAILURE_MISSING_CSRF_URL =
@@ -29,7 +26,6 @@ const FAILURE_MISSING_URL = "Value for URL must be provided!";
 export abstract class BaseHttpClient<RequestConfigType> implements ODataHttpClient<RequestConfigType> {
   private csrfToken: string | undefined;
   private csrfTokenKey = DEFAULT_CSRF_TOKEN_KEY;
-  private bigNumbersAsString: boolean = false;
 
   protected retrieveErrorMessage: ErrorMessageRetriever = retrieveErrorMessage;
 
@@ -118,9 +114,8 @@ export abstract class BaseHttpClient<RequestConfigType> implements ODataHttpClie
     }
 
     // use big numbers
-    let config = this.bigNumbersAsString
-      ? this.addHeaderToRequestConfig(BIG_NUMBERS_HEADERS, requestConfig)
-      : requestConfig;
+    let config = requestConfig;
+
     // use additional headers
     if (additionalHeaders) {
       config = this.addHeaderToRequestConfig(additionalHeaders, config);
@@ -186,26 +181,12 @@ export abstract class BaseHttpClient<RequestConfigType> implements ODataHttpClie
   ): Promise<HttpResponseModel<ResponseModel>> {
     return this.sendRequest<ResponseModel>(HttpMethods.Patch, url, data, requestConfig, additionalHeaders);
   }
-  public merge<ResponseModel>(
-    url: string,
-    data: any,
-    requestConfig?: RequestConfigType,
-    additionalHeaders?: Record<string, string>
-  ): Promise<HttpResponseModel<ResponseModel>> {
-    return this.sendRequest<ResponseModel>(HttpMethods.Post, url, data, requestConfig, {
-      ...MERGE_HEADERS,
-      ...additionalHeaders,
-    });
-  }
+
   public delete(
     url: string,
     requestConfig?: RequestConfigType,
     additionalHeaders?: Record<string, string>
   ): Promise<HttpResponseModel<void>> {
     return this.sendRequest<void>(HttpMethods.Delete, url, undefined, requestConfig, additionalHeaders);
-  }
-
-  public retrieveBigNumbersAsString(enabled: boolean) {
-    this.bigNumbersAsString = enabled;
   }
 }

--- a/packages/http-client-base/test/BaseHttpClient.test.ts
+++ b/packages/http-client-base/test/BaseHttpClient.test.ts
@@ -119,56 +119,6 @@ describe("BaseHttpClient Tests", () => {
     expect(mockClient.lastConfig).toStrictEqual(DEFAULT_CONFIG);
   });
 
-  test("simple MERGE request", async () => {
-    await mockClient.merge(DEFAULT_URL, DEFAULT_DATA);
-
-    expect(mockClient.lastMethod).toBe("POST");
-    expect(mockClient.lastUrl).toBe(DEFAULT_URL);
-    expect(mockClient.lastData).toStrictEqual(DEFAULT_DATA);
-    expect(mockClient.lastConfig).toStrictEqual({ headers: { "X-Http-Method": "MERGE" } });
-  });
-
-  test("MERGE with config", async () => {
-    await mockClient.merge(DEFAULT_URL, DEFAULT_DATA, DEFAULT_CONFIG);
-
-    expect(mockClient.lastMethod).toBe("POST");
-    expect(mockClient.lastUrl).toBe(DEFAULT_URL);
-    expect(mockClient.lastData).toStrictEqual(DEFAULT_DATA);
-    expect(mockClient.lastConfig).toStrictEqual({
-      ...DEFAULT_CONFIG,
-      headers: { ...{ "X-Http-Method": "MERGE" }, ...DEFAULT_CONFIG.headers },
-    });
-  });
-
-  test("MERGE: config wins over internally set headers", async () => {
-    const myHeaderConfig = { "X-Http-Method": "MyMerge" };
-    await mockClient.merge(DEFAULT_URL, DEFAULT_DATA, { headers: myHeaderConfig });
-
-    expect(mockClient.lastConfig).toStrictEqual({
-      headers: myHeaderConfig,
-    });
-  });
-
-  test("MERGE with additional headers", async () => {
-    const mergeHeader = { "X-Http-Method": "MERGE" };
-
-    // only additional headers
-    await mockClient.merge(DEFAULT_URL, DEFAULT_DATA, undefined, ADDITIONAL_HEADERS);
-    expect(mockClient.lastConfig).toStrictEqual({ headers: { ...mergeHeader, ...ADDITIONAL_HEADERS } });
-
-    // request config & additional headers get merged
-    await mockClient.merge(DEFAULT_URL, DEFAULT_DATA, DEFAULT_CONFIG, ADDITIONAL_HEADERS);
-    expect(mockClient.lastConfig).toStrictEqual({
-      ...DEFAULT_CONFIG,
-      headers: { "X-Http-Method": "MERGE", ...DEFAULT_CONFIG.headers, ...ADDITIONAL_HEADERS },
-    });
-
-    // request config wins over additional headers
-    const rc = { headers: { "Content-Type": "heyHo!!!" } };
-    await mockClient.merge(DEFAULT_URL, DEFAULT_DATA, rc, ADDITIONAL_HEADERS);
-    expect(mockClient.lastConfig).toStrictEqual({ headers: { ...mergeHeader, ...rc.headers } });
-  });
-
   test("simple DELETE request", async () => {
     await mockClient.delete(DEFAULT_URL);
 
@@ -205,20 +155,5 @@ describe("BaseHttpClient Tests", () => {
     mockClient.setErrorMessageRetriever((responseData: any) => message + responseData);
 
     expect(mockClient.exposedErrorMessageRetriever("hi")).toBe(message + "hi");
-  });
-
-  test("retrieve big numbers as string", async () => {
-    mockClient.retrieveBigNumbersAsString(true);
-    await mockClient.get(DEFAULT_URL);
-
-    expect(mockClient.lastConfig?.headers).toStrictEqual({
-      Accept: "application/json;IEEE754Compatible=true",
-      "Content-Type": "application/json;IEEE754Compatible=true",
-    });
-
-    mockClient.retrieveBigNumbersAsString(false);
-    await mockClient.get(DEFAULT_URL);
-
-    expect(mockClient.lastConfig?.headers).toBeUndefined();
   });
 });

--- a/packages/jquery/int-test/HttpCommunication.test.ts
+++ b/packages/jquery/int-test/HttpCommunication.test.ts
@@ -2,46 +2,136 @@ import { ODataCollectionResponseV4, ODataModelResponseV4 } from "@odata2ts/odata
 import jQuery from "jquery";
 import { JSDOM } from "jsdom";
 
-import { JQueryClient } from "../src";
+import { JQueryClient, JQueryClientError } from "../src";
 
 describe("HTTP Communication Tests", function () {
-  const BASE_URL = "https://services.odata.org/TripPinRESTierService/(S(xxxsujx4iqjss1vkeighyks6))";
+  const BASE_URL = "https://services.odata.org/TripPinRESTierService/(S(xxxsujx4iqjss1vkeighyks8))";
+  const DEFAULT_HEADERS = { Accept: "application/json", "Content-Type": "application/json" };
 
   const $ = jQuery(new JSDOM().window) as unknown as JQueryStatic;
-  const REAL_CLIENT = new JQueryClient($);
+  const REAL_CLIENT = new JQueryClient($, { headers: DEFAULT_HEADERS });
 
   test("Simple Get", async () => {
-    const response = await REAL_CLIENT.get<ODataCollectionResponseV4<any>>(BASE_URL + "/");
-    expect(response.data?.value[0]).toStrictEqual({
-      name: "People",
-      kind: "EntitySet",
-      url: "People",
+    const response = await REAL_CLIENT.get<ODataCollectionResponseV4<any>>(BASE_URL + "/People('russellwhyte')");
+    expect(response).toMatchObject({
+      status: 200,
+      statusText: "OK",
     });
-    expect(response.headers).toMatchObject({
+    expect(response.headers).toStrictEqual({
+      "content-length": "445",
       "content-type": "application/json; odata.metadata=minimal",
+      "cache-control": "no-cache",
+      // "content-encoding": "gzip",
+      expires: "-1",
+      pragma: "no-cache",
+      // "odata-version": "4.0",
+      // server: "Microsoft-IIS/10.0",
+      // vary: "Accept-Encoding",
+      // "x-aspnet-version": "4.0.30319",
+      // "x-powered-by": "ASP.NET",
+    });
+    expect(response.data).toMatchObject({
+      FirstName: "Russell",
+      LastName: "Whyte",
+      Emails: ["Russell@example.com", "Russell@contoso.com"],
     });
   });
 
-  test("PATCH request", async () => {
-    const response = await REAL_CLIENT.patch<void>(BASE_URL + "/People('russellwhyte')", {
-      MiddleName: "kk",
-    });
-    expect(response.data).toBeUndefined();
+  test("404", async () => {
+    const expectedErrorMsg = "The request resource is not found.";
+
+    try {
+      await REAL_CLIENT.get(BASE_URL + "/People('xxxYxxx')");
+      expect(true).toBeFalsy();
+    } catch (e) {
+      expect(e).toBeInstanceOf(JQueryClientError);
+
+      const error = e as JQueryClientError;
+      expect(error.message).toBe(`OData server responded with error: ${expectedErrorMsg}`);
+      expect(error).toMatchObject({
+        name: "JQueryClientError",
+        status: 404,
+      });
+      expect(error.cause?.message).toContain(expectedErrorMsg);
+      expect(error.stack).toMatch(expectedErrorMsg);
+      expect(error.stack).toMatch(error.name);
+    }
   });
 
-  test("POST, PUT and DELETE request", async () => {
-    const id = "heineritis";
-    await REAL_CLIENT.post<ODataModelResponseV4<any>>(BASE_URL + "/People", {
-      UserName: id,
-      FirstName: "Heiner",
-      LastName: "Itis",
+  const entitySetUrl = BASE_URL + "/People";
+  const id = "heineritis";
+  const entityUrl = `${entitySetUrl}('${id}')`;
+  const model = {
+    UserName: id,
+    FirstName: "Heiner",
+    LastName: "Itis",
+  };
+
+  describe("Create Own Entity", function () {
+    test("POST", async () => {
+      // delete the entity we want to create => required if any test failed
+      try {
+        await REAL_CLIENT.delete(entityUrl);
+      } catch (e) {
+        //ignore
+      }
+
+      let response = await REAL_CLIENT.post<ODataModelResponseV4<any>>(entitySetUrl, model);
+
+      expect(response).toMatchObject({
+        status: 201,
+        statusText: "Created",
+        headers: {
+          "cache-control": "no-cache",
+          "content-type": "application/json; odata.metadata=minimal",
+          // visibility of some additional headers depends on CORS settings of server
+          // location: entityUrl,
+        },
+      });
+      expect(response.data).toMatchObject(model);
+    });
+  });
+
+  describe("Manipulate Own Entity", function () {
+    test("PUT", async () => {
+      const newModel = {
+        FirstName: "Horst",
+        Age: 34,
+      };
+      let response = await REAL_CLIENT.put<void>(entityUrl, newModel);
+      expect(response).toMatchObject({
+        status: 204,
+        statusText: "No Content",
+        data: undefined,
+      });
+
+      response = await REAL_CLIENT.get(entityUrl);
+      expect(response.data).toMatchObject(newModel);
     });
 
-    await REAL_CLIENT.put<void>(BASE_URL + "/People('heineritis')", {
-      FirstName: "Horst",
-      LastName: "Itis",
-    });
+    test("PATCH", async () => {
+      const response = await REAL_CLIENT.patch<void>(entityUrl, {
+        MiddleName: "kk",
+      });
+      expect(response).toMatchObject({
+        status: 204,
+        statusText: "No Content",
+        data: undefined,
+      });
 
-    await REAL_CLIENT.delete(BASE_URL + "/People('heineritis')");
+      const response2 = await REAL_CLIENT.get<ODataModelResponseV4<any>>(entityUrl);
+      expect(response2.data.MiddleName).toBe("kk");
+    });
+  });
+
+  describe("Delete Own Entity", function () {
+    test("DELETE", async () => {
+      const response = await REAL_CLIENT.delete(entityUrl);
+      expect(response).toMatchObject({
+        status: 204,
+        statusText: "No Content",
+        data: undefined,
+      });
+    });
   });
 });

--- a/packages/jquery/src/AjaxRequestConfig.ts
+++ b/packages/jquery/src/AjaxRequestConfig.ts
@@ -2,8 +2,7 @@ const DEFAULT_CONFIG: JQuery.AjaxSettings = {
   // we never want caching
   cache: false,
   // we always want JSON
-  dataType: "json",
-  headers: { Accept: "application/json", "Content-Type": "application/json" },
+  // dataType: "json",
 };
 
 /**

--- a/packages/jquery/src/JQueryClient.ts
+++ b/packages/jquery/src/JQueryClient.ts
@@ -43,7 +43,7 @@ export class JQueryClient extends BaseHttpClient<AjaxRequestConfig> {
     return mergeAjaxConfig({ headers }, config);
   }
 
-  protected executeRequest<ResponseModel>(
+  protected async executeRequest<ResponseModel>(
     method: HttpMethods,
     url: string,
     data: any,
@@ -67,9 +67,9 @@ export class JQueryClient extends BaseHttpClient<AjaxRequestConfig> {
           });
         },
         error: (jqXHR: JQuery.jqXHR, textStatus: string, thrownError: string) => {
-          const responseMessage = this.retrieveErrorMessage(jqXHR.responseJSON());
+          const responseMessage = this.retrieveErrorMessage(jqXHR?.responseJSON);
           const failMsg = responseMessage ?? thrownError ?? DEFAULT_ERROR_MESSAGE;
-          const errorMessage = responseMessage ? "Server responded with error: " + responseMessage : failMsg;
+          const errorMessage = responseMessage ? "OData server responded with error: " + responseMessage : failMsg;
           const responseHeaders = this.mapHeaders(jqXHR);
           reject(new JQueryClientError(errorMessage, jqXHR.status, responseHeaders, new Error(failMsg), jqXHR));
         },

--- a/packages/jquery/test/JQueryMock.ts
+++ b/packages/jquery/test/JQueryMock.ts
@@ -13,7 +13,7 @@ function createMockXhr(status: number, statusText: string, data: any, headers: {
     statusText,
     getResponseHeader: (name: string) => (headers ? headers[name] : undefined),
     getAllResponseHeaders: () => respHeaders,
-    responseJSON: () => data,
+    responseJSON: data,
   };
 }
 


### PR DESCRIPTION
Remove stuff which can also be handled by the new `additionalHeaders` option:
* `merge` operation: simualted as POST with special request header
* `writeBigNumbersAsString`

Remove certain defaults from the individual http clients:
* `Accept` & `Content-Type` header
* jquery: `dataType=json` option