### PR TITLE
refactor: expand additionalHeaders param to internalConfig

### DIFF
--- a/packages/axios/src/AxiosClient.ts
+++ b/packages/axios/src/AxiosClient.ts
@@ -1,4 +1,4 @@
-import { HttpResponseModel } from "@odata2ts/http-client-api";
+import { HttpResponseModel, InternalHttpClientConfig } from "@odata2ts/http-client-api";
 import { BaseHttpClient, BaseHttpClientOptions, HttpMethods } from "@odata2ts/http-client-base";
 import axios, {
   AxiosError,
@@ -27,26 +27,21 @@ function buildErrorMessage(prefix: string, error: any) {
 export class AxiosClient extends BaseHttpClient<AxiosRequestConfig> {
   protected readonly client: AxiosInstance;
 
-  constructor(config?: AxiosRequestConfig, private clientOptions?: ClientOptions) {
+  constructor(config?: AxiosRequestConfig, clientOptions?: ClientOptions) {
     super(clientOptions);
     this.client = axios.create(config);
-  }
-
-  protected addHeaderToRequestConfig(
-    headers: Record<string, string>,
-    config: AxiosRequestConfig | undefined
-  ): AxiosRequestConfig {
-    return mergeConfig({ headers }, config);
   }
 
   protected async executeRequest<ResponseModel>(
     method: HttpMethods,
     url: string,
     data: any,
-    requestConfig: AxiosRequestConfig | undefined = {}
+    requestConfig: AxiosRequestConfig | undefined = {},
+    internalConfig: InternalHttpClientConfig = {}
   ): Promise<HttpResponseModel<ResponseModel>> {
-    // add URL and HTTP method to the request config
-    const config: OriginalRequestConfig = mergeConfig(requestConfig, { url, method });
+    // add URL, HTTP method and additional headers to the request config
+    const { headers } = internalConfig;
+    const config: OriginalRequestConfig = mergeConfig({ headers }, requestConfig, { url, method });
     if (typeof data !== "undefined") {
       config.data = data;
     }

--- a/packages/axios/test/AxiosODataClient.test.ts
+++ b/packages/axios/test/AxiosODataClient.test.ts
@@ -85,7 +85,7 @@ describe("Axios HTTP Client Tests", function () {
   test("using additional headers", async () => {
     const headers = { hey: "Ho" };
 
-    await axiosClient.get("", undefined, headers);
+    await axiosClient.get("", undefined, { headers });
 
     expect(requestConfig?.headers).toStrictEqual(headers);
   });
@@ -98,7 +98,7 @@ describe("Axios HTTP Client Tests", function () {
       method: "POST",
     };
 
-    await axiosClient.get("", { headers, ...config }, { test: "added", extra: "x" });
+    await axiosClient.get("", { headers, ...config }, { headers: { test: "added", extra: "x" } });
 
     // method has not been overridden
     expect(requestConfig?.method).toBe("GET");

--- a/packages/fetch/src/FetchClient.ts
+++ b/packages/fetch/src/FetchClient.ts
@@ -1,4 +1,4 @@
-import { HttpResponseModel } from "@odata2ts/http-client-api";
+import { HttpResponseModel, InternalHttpClientConfig } from "@odata2ts/http-client-api";
 import { BaseHttpClient, BaseHttpClientOptions, HttpMethods } from "@odata2ts/http-client-base";
 
 import { FetchClientError } from "./FetchClientError";
@@ -24,20 +24,15 @@ export class FetchClient extends BaseHttpClient<FetchRequestConfig> {
     this.config = getDefaultConfig(config);
   }
 
-  protected addHeaderToRequestConfig(
-    headers: Record<string, string>,
-    config: FetchRequestConfig | undefined
-  ): FetchRequestConfig {
-    return mergeFetchConfig({ headers }, config);
-  }
-
   protected async executeRequest<ResponseModel>(
     method: HttpMethods,
     url: string,
     data: any,
-    requestConfig: FetchRequestConfig | undefined = {}
+    requestConfig: FetchRequestConfig | undefined = {},
+    internalConfig: InternalHttpClientConfig = {}
   ): Promise<HttpResponseModel<ResponseModel>> {
-    const { params, ...config } = mergeFetchConfig(this.config, requestConfig);
+    const { headers, noBodyEvaluation } = internalConfig;
+    const { params, ...config } = mergeFetchConfig(this.config, { headers }, requestConfig);
     config.method = method;
     if (typeof data !== "undefined") {
       config.body = JSON.stringify(data);
@@ -77,7 +72,7 @@ export class FetchClient extends BaseHttpClient<FetchRequestConfig> {
       );
     }
 
-    const responseData = await this.getResponseBody(response, true);
+    const responseData = noBodyEvaluation ? undefined : await this.getResponseBody(response, true);
 
     return {
       status: response.status,

--- a/packages/fetch/test/FailureHandling.test.ts
+++ b/packages/fetch/test/FailureHandling.test.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_ERROR_MESSAGE, FetchClient, FetchClientError, FetchRequestConfig } from "../src";
+import { DEFAULT_ERROR_MESSAGE, FetchClient, FetchClientError } from "../src";
 
 describe("Failure Handling Tests", function () {
   const RESPONSE_HEADERS = { "content-type": "application/json" };

--- a/packages/fetch/test/FetchODataClient.test.ts
+++ b/packages/fetch/test/FetchODataClient.test.ts
@@ -97,7 +97,7 @@ describe("FetchClient Tests", function () {
   test("using additional headers", async () => {
     const headers = { hey: "Ho" };
 
-    await fetchClient.get("", undefined, headers);
+    await fetchClient.get("", undefined, { headers });
 
     expect(getRequestHeaderRecords()).toStrictEqual(headers);
   });
@@ -110,7 +110,7 @@ describe("FetchClient Tests", function () {
       cache: "force-cache",
     };
 
-    await fetchClient.get("", { headers, ...config }, { test: "added" });
+    await fetchClient.get("", { headers, ...config }, { headers: { test: "added" } });
 
     // method has not been overridden
     expect(getBaseRequestConfig()).toStrictEqual({ method: "GET", cache: config.cache });

--- a/packages/http-client-api/src/ODataHttpClient.ts
+++ b/packages/http-client-api/src/ODataHttpClient.ts
@@ -7,6 +7,17 @@ export type ODataHttpClientConfig<ClientType extends ODataHttpClient> = ClientTy
   ? Config
   : never;
 
+export interface InternalHttpClientConfig {
+  /**
+   * Additional headers set internally by services or HttpClient implementation.
+   */
+  headers?: Record<string, string>;
+  /**
+   * Very special option needed for FetchClient to not evaluate the response body in certain situations.
+   */
+  noBodyEvaluation?: boolean;
+}
+
 export interface ODataHttpClient<RequestConfig = any> {
   /**
    * Create a model or collection entry.
@@ -14,19 +25,19 @@ export interface ODataHttpClient<RequestConfig = any> {
    * @param url
    * @param data
    * @param requestConfig
-   * @param additionalHeaders
+   * @param config
    */
   post<ResponseModel>(
     url: string,
     data: any,
     requestConfig?: RequestConfig,
-    additionalHeaders?: Record<string, string>
+    config?: InternalHttpClientConfig
   ): ODataResponse<ResponseModel>;
 
   get<ResponseModel>(
     url: string,
     requestConfig?: RequestConfig,
-    additionalHeaders?: Record<string, string>
+    config?: InternalHttpClientConfig
   ): ODataResponse<ResponseModel>;
 
   /**
@@ -35,13 +46,13 @@ export interface ODataHttpClient<RequestConfig = any> {
    * @param url
    * @param data
    * @param requestConfig
-   * @param additionalHeaders
+   * @param config
    */
   put<ResponseModel>(
     url: string,
     data: any,
     requestConfig?: RequestConfig,
-    additionalHeaders?: Record<string, string>
+    config?: InternalHttpClientConfig
   ): ODataResponse<ResponseModel>;
 
   /**
@@ -50,13 +61,13 @@ export interface ODataHttpClient<RequestConfig = any> {
    * @param url
    * @param data
    * @param requestConfig
-   * @param additionalHeaders
+   * @param config
    */
   patch<ResponseModel>(
     url: string,
     data: any,
     requestConfig?: RequestConfig,
-    additionalHeaders?: Record<string, string>
+    config?: InternalHttpClientConfig
   ): ODataResponse<ResponseModel>;
 
   /**
@@ -64,7 +75,7 @@ export interface ODataHttpClient<RequestConfig = any> {
    *
    * @param url
    * @param requestConfig
-   * @param additionalHeaders
+   * @param config
    */
-  delete(url: string, requestConfig?: RequestConfig, additionalHeaders?: Record<string, string>): ODataResponse<void>;
+  delete(url: string, requestConfig?: RequestConfig, config?: InternalHttpClientConfig): ODataResponse<void>;
 }

--- a/packages/http-client-base/README.md
+++ b/packages/http-client-base/README.md
@@ -25,7 +25,7 @@ Extend the class `BaseHttpClient` to simplify your HttpClient implementation.
 You need to implement two abstract methods:
 
 ```ts
-import { BaseHttpClient, BaseHttpClientOptions } from "@odata2ts/http-client-base";
+import { BaseHttpClient, BaseHttpClientOptions, InternalHttpClientConfig } from "@odata2ts/http-client-base";
 
 export interface MyRequestConfig {}
 
@@ -33,19 +33,13 @@ export class MyHttpClient extends BaseHttpClient<MyRequestConfig> {
     constructor(clientOptions: BaseHttpClientOptions) {
         super(clientOptions);
     }
-
-    protected addHeaderToRequestConfig(
-        headers: Record<string, string>,
-        config: BaseHttpClient | undefined
-    ): MyRequestConfig {
-        // your implementation
-    }
-
+    
     protected async executeRequest<ResponseModel>(
         method: HttpMethods,
         url: string,
         data: any,
-        requestConfig: AxiosRequestConfig | undefined = {}
+        requestConfig: AxiosRequestConfig | undefined = {},
+        internalConfig?: InternalHttpClientConfig
     ): Promise<HttpResponseModel<ResponseModel>> {
         // your implementation
     }

--- a/packages/http-client-base/test/BaseHttpClient.test.ts
+++ b/packages/http-client-base/test/BaseHttpClient.test.ts
@@ -3,7 +3,7 @@ import { MockClientError, MockHttpClient, MockRequestConfig } from "./MockHttpCl
 describe("BaseHttpClient Tests", () => {
   const DEFAULT_URL = "http://test.testing.com/myService/theEntity";
   const DEFAULT_CONFIG: MockRequestConfig = { headers: { x: "a" }, x: "y" };
-  const ADDITIONAL_HEADERS = { "Content-Type": "ct" };
+  const INTERNAL_CONFIG = { headers: { "Content-Type": "ct" } };
   const DEFAULT_DATA = { a: "b" };
 
   let mockClient: MockHttpClient;
@@ -38,13 +38,13 @@ describe("BaseHttpClient Tests", () => {
   });
 
   test("GET with additional headers", async () => {
-    await mockClient.get(DEFAULT_URL, undefined, ADDITIONAL_HEADERS);
-    expect(mockClient.lastConfig).toStrictEqual({ headers: ADDITIONAL_HEADERS });
+    await mockClient.get(DEFAULT_URL, undefined, INTERNAL_CONFIG);
+    expect(mockClient.lastConfig).toStrictEqual({ headers: INTERNAL_CONFIG.headers });
 
-    await mockClient.get(DEFAULT_URL, DEFAULT_CONFIG, ADDITIONAL_HEADERS);
+    await mockClient.get(DEFAULT_URL, DEFAULT_CONFIG, INTERNAL_CONFIG);
     expect(mockClient.lastConfig).toStrictEqual({
       ...DEFAULT_CONFIG,
-      headers: { ...DEFAULT_CONFIG.headers, ...ADDITIONAL_HEADERS },
+      headers: { ...DEFAULT_CONFIG.headers, ...INTERNAL_CONFIG.headers },
     });
   });
 

--- a/packages/jquery/src/JQueryClient.ts
+++ b/packages/jquery/src/JQueryClient.ts
@@ -1,6 +1,6 @@
 /// <reference path="../../../node_modules/@types/jquery/JQueryStatic.d.ts" />
 
-import { HttpResponseModel } from "@odata2ts/http-client-api";
+import { HttpResponseModel, InternalHttpClientConfig } from "@odata2ts/http-client-api";
 import { BaseHttpClient, BaseHttpClientOptions, HttpMethods } from "@odata2ts/http-client-base";
 
 import { AjaxRequestConfig, getDefaultConfig, mergeAjaxConfig } from "./AjaxRequestConfig";
@@ -16,7 +16,7 @@ export class JQueryClient extends BaseHttpClient<AjaxRequestConfig> {
   private readonly client: JQueryStatic;
   private readonly config: JQuery.AjaxSettings;
 
-  constructor(jquery: JQueryStatic, config?: AjaxRequestConfig, private clientOptions?: ClientOptions) {
+  constructor(jquery: JQueryStatic, config?: AjaxRequestConfig, clientOptions?: ClientOptions) {
     super(clientOptions);
     this.client = jquery;
     this.config = getDefaultConfig(config);
@@ -39,17 +39,15 @@ export class JQueryClient extends BaseHttpClient<AjaxRequestConfig> {
       }, {});
   }
 
-  protected addHeaderToRequestConfig(headers: Record<string, string>, config?: AjaxRequestConfig): AjaxRequestConfig {
-    return mergeAjaxConfig({ headers }, config);
-  }
-
   protected async executeRequest<ResponseModel>(
     method: HttpMethods,
     url: string,
     data: any,
-    requestConfig?: JQuery.AjaxSettings
+    requestConfig?: JQuery.AjaxSettings,
+    internalConfig: InternalHttpClientConfig = {}
   ): Promise<HttpResponseModel<ResponseModel>> {
-    const { params, ...mergedConfig } = mergeAjaxConfig(this.config, requestConfig);
+    const withInternalConfig = mergeAjaxConfig({ headers: internalConfig.headers }, requestConfig);
+    const { params, ...mergedConfig } = mergeAjaxConfig(this.config, withInternalConfig);
     mergedConfig.method = method;
     mergedConfig.data = JSON.stringify(data);
     mergedConfig.url = url;

--- a/packages/jquery/test/FailureHandling.test.ts
+++ b/packages/jquery/test/FailureHandling.test.ts
@@ -1,5 +1,4 @@
-import { AjaxRequestConfig, JQueryClient, JQueryClientError } from "../src";
-import { DEFAULT_ERROR_MESSAGE } from "../src/JQueryClient";
+import { DEFAULT_ERROR_MESSAGE, JQueryClient, JQueryClientError } from "../src";
 import { JqMock } from "./JQueryMock";
 
 describe("JQueryClient Failure Handling Tests", function () {
@@ -7,33 +6,7 @@ describe("JQueryClient Failure Handling Tests", function () {
   let jqClient: JQueryClient;
 
   const DEFAULT_URL = "TEST/hi";
-  const JSON_VALUE = "application/json";
-  const DEFAULT_HEADERS = { Accept: JSON_VALUE, "Content-Type": JSON_VALUE };
-  const DEFAULT_REQUEST_CONFIG: AjaxRequestConfig = { timeout: 666, headers: { test: "test" } };
   const RESPONSE_HEADERS = { "content-type": "application/json" };
-
-  const DEFAULT_CONFIG = {
-    url: DEFAULT_URL,
-    method: "GET",
-    dataType: "json",
-    cache: false,
-  };
-
-  const getRequestData = () => {
-    return jqMock.getRequestConfig()?.data;
-  };
-
-  const getRequestHeaders = () => {
-    return jqMock.getRequestConfig()?.headers;
-  };
-
-  /**
-   * request config without headers
-   */
-  const getRequestDetails = () => {
-    const { data, headers, success, error, ...result } = jqMock.getRequestConfig() || {};
-    return result;
-  };
 
   function createFailureMsg(message: string, isV2: boolean = false) {
     return { error: { message: isV2 ? { value: message } : message } };

--- a/packages/jquery/test/JQueryClient.test.ts
+++ b/packages/jquery/test/JQueryClient.test.ts
@@ -1,5 +1,3 @@
-import { FetchClient } from "@odata2ts/http-client-fetch";
-
 import { AjaxRequestConfig, JQueryClient } from "../src";
 import { JqMock } from "./JQueryMock";
 
@@ -78,7 +76,7 @@ describe("JQueryClient Tests", function () {
   test("using additional headers", async () => {
     const headers = { hey: "Ho", "Content-Type": "tester" };
 
-    await jqClient.get(DEFAULT_URL, undefined, headers);
+    await jqClient.get(DEFAULT_URL, undefined, { headers });
 
     expect(getRequestHeaders()).toStrictEqual(headers);
   });
@@ -94,7 +92,7 @@ describe("JQueryClient Tests", function () {
       headers,
     };
 
-    await jqClient.get("", config, { test: "added", extra: "x" });
+    await jqClient.get("", config, { headers: { test: "added", extra: "x" } });
 
     // method has not been overridden
     expect(getRequestDetails()).toMatchObject({ method: "GET" });


### PR DESCRIPTION
BREAKING CHANGE: additional headers are now part of the config parameter

fixes loss of configuration when CSRF token is active; adds new option which prevents FetchClient from evaluating response body (not needed for fetching csrf tokens)