### PR TITLE
feat: add generic request method

### DIFF
--- a/packages/http-client-api/src/ODataHttpClient.ts
+++ b/packages/http-client-api/src/ODataHttpClient.ts
@@ -1,3 +1,4 @@
+import { ODataHttpMethods } from "./ODataHttpMethods";
 import { ODataRequestConfig } from "./ODataRequestConfig";
 import { ODataResponse } from "./ODataResponseModel";
 
@@ -67,6 +68,23 @@ export interface ODataHttpClient<RequestConfig extends ODataRequestConfig = ODat
    * @param additionalHeaders
    */
   delete(url: string, requestConfig?: RequestConfig, additionalHeaders?: Record<string, string>): ODataResponse<void>;
+
+  /**
+   * Generic function to call one of the above methods via method enum.
+   *
+   * @param url
+   * @param method
+   * @param data
+   * @param requestConfig
+   * @param additionalHeaders
+   */
+  request<ResponseModel>(
+    url: string,
+    method: ODataHttpMethods,
+    data: any,
+    requestConfig?: RequestConfig,
+    additionalHeaders?: Record<string, string>,
+  ): ODataResponse<ResponseModel>;
 
   /**
    * Get binary data (Edm.Stream) as Blob.

--- a/packages/http-client-base/src/BaseHttpClient.ts
+++ b/packages/http-client-base/src/BaseHttpClient.ts
@@ -246,6 +246,22 @@ export abstract class BaseHttpClient<RequestConfigType> {
     );
   }
 
+  public request<ResponseModel>(
+    url: string,
+    method: ODataHttpMethods,
+    data: any,
+    requestConfig?: RequestConfigType,
+    additionalHeaders?: Record<string, string>,
+  ): Promise<HttpResponseModel<ResponseModel>> {
+    return this.sendRequest<ResponseModel>(
+      method,
+      url,
+      data,
+      requestConfig,
+      getInternalConfigWithJsonHeaders(additionalHeaders),
+    );
+  }
+
   public getBlob(
     url: string,
     requestConfig?: RequestConfigType,

--- a/packages/http-client-base/test/BaseHttpClient.test.ts
+++ b/packages/http-client-base/test/BaseHttpClient.test.ts
@@ -156,6 +156,23 @@ describe("BaseHttpClient Tests", () => {
     expect(mockClient.lastConfig).toStrictEqual(DEFAULT_CONFIG);
   });
 
+  test("generic GET request", async () => {
+    await mockClient.request(DEFAULT_URL, ODataHttpMethods.Get, undefined);
+
+    expect(mockClient.lastMethod).toBe(ODataHttpMethods.Get);
+    expect(mockClient.lastUrl).toBe(DEFAULT_URL);
+    expect(mockClient.lastData).toBeUndefined();
+  });
+
+  test("generic POST request with config", async () => {
+    await mockClient.request(DEFAULT_URL, ODataHttpMethods.Post, DEFAULT_DATA, DEFAULT_CONFIG);
+
+    expect(mockClient.lastMethod).toBe(ODataHttpMethods.Post);
+    expect(mockClient.lastUrl).toBe(DEFAULT_URL);
+    expect(mockClient.lastData).toStrictEqual(DEFAULT_DATA);
+    expect(mockClient.lastConfig).toStrictEqual(DEFAULT_CONFIG);
+  });
+
   test("get blob request", async () => {
     await mockClient.getBlob(DEFAULT_URL);
 


### PR DESCRIPTION
Calling `request` with the method instead of directly calling `get`, etc.