### PR TITLE
fix: send a plain text request body as it is

### DIFF
--- a/packages/axios/test/AxiosODataClient.test.ts
+++ b/packages/axios/test/AxiosODataClient.test.ts
@@ -130,6 +130,18 @@ describe("Axios HTTP Client Tests", function () {
     expect(requestConfig?.data).toStrictEqual(dataStructure);
   });
 
+  /**
+   * Axios serializes the body itself and leaves strings alone, so this client never suffered from the
+   * double quoting of https://github.com/odata2ts/odata2ts/issues/383. Pinned to keep it that way.
+   */
+  test("post request with plain text body", async () => {
+    const query = "%24select=UserName&%24top=10";
+
+    await axiosClient.post("", query, undefined, { "Content-Type": "text/plain" });
+
+    expect(requestConfig?.data).toBe(query);
+  });
+
   test("put request", async () => {
     await axiosClient.put(DEFAULT_URL, {});
 

--- a/packages/fetch/src/FetchClient.ts
+++ b/packages/fetch/src/FetchClient.ts
@@ -46,7 +46,8 @@ export class FetchClient extends BaseHttpClient<FetchRequestConfig> implements O
       method,
     };
     if (typeof data !== "undefined") {
-      resultConfig.body = internalConfig.dataType === ODataHttpDataTypes.JSON ? JSON.stringify(data) : data;
+      resultConfig.body =
+        ODataHttpDataTypes.JSON && !this.isPlainTextBody(internalConfig.headers) ? JSON.stringify(data) : data;
     }
 
     // apply additional query params to the URL

--- a/packages/fetch/src/FetchClient.ts
+++ b/packages/fetch/src/FetchClient.ts
@@ -46,8 +46,9 @@ export class FetchClient extends BaseHttpClient<FetchRequestConfig> implements O
       method,
     };
     if (typeof data !== "undefined") {
-      resultConfig.body =
-        ODataHttpDataTypes.JSON && !this.isPlainTextBody(internalConfig.headers) ? JSON.stringify(data) : data;
+      const serializeAsJson =
+        internalConfig.dataType === ODataHttpDataTypes.JSON && !this.isPlainTextBody(internalConfig.headers);
+      resultConfig.body = serializeAsJson ? JSON.stringify(data) : data;
     }
 
     // apply additional query params to the URL

--- a/packages/fetch/test/FetchODataClient.test.ts
+++ b/packages/fetch/test/FetchODataClient.test.ts
@@ -144,6 +144,20 @@ describe("FetchClient Tests", function () {
     expect(requestConfig?.body).toBe(JSON.stringify(dataStructure));
   });
 
+  /**
+   * A plain text body goes over the wire as it is: JSON serializing it would wrap it into double quotes,
+   * which the server cannot parse. See https://github.com/odata2ts/odata2ts/issues/383.
+   */
+  test("post request with plain text body", async () => {
+    const query = "%24select=UserName&%24top=10";
+
+    await fetchClient.post("", query, undefined, { "Content-Type": "text/plain" });
+
+    expect(requestConfig?.body).toBe(query);
+    expect(requestConfig?.body).not.toMatch(/^"/);
+    expect(getRequestHeaderRecords()).toMatchObject({ "content-type": "text/plain" });
+  });
+
   test("put request", async () => {
     await fetchClient.put(DEFAULT_URL, {});
 

--- a/packages/http-client-base/src/BaseHttpClient.ts
+++ b/packages/http-client-base/src/BaseHttpClient.ts
@@ -23,6 +23,8 @@ const FAILURE_MISSING_CSRF_URL =
   "When automatic CSRF token handling is activated, the URL must be supplied via attribute [csrfTokenFetchUrl]!";
 const FAILURE_MISSING_URL = "Value for URL must be provided!";
 const JSON_VALUE = "application/json";
+const PLAIN_TEXT_VALUE = "text/plain";
+const CONTENT_TYPE_KEY = "content-type";
 
 function getInternalConfigWithJsonHeaders(
   headers?: Record<string, string>,
@@ -63,6 +65,23 @@ export abstract class BaseHttpClient<RequestConfigType> {
     if (baseOptions.useCsrfProtection && !baseOptions.csrfTokenFetchUrl?.trim()) {
       throw new Error(FAILURE_MISSING_CSRF_URL);
     }
+  }
+
+  /**
+   * Whether the given headers declare the request body as plain text, in which case it must be passed
+   * to the server as it is: serializing it as JSON would wrap it into double quotes.
+   *
+   * The header name is matched case-insensitively, since callers are free to choose their own spelling.
+   * Of multiple matches the last one wins, mirroring how the headers were merged in the first place.
+   *
+   * @param headers the headers of the request
+   */
+  protected isPlainTextBody(headers?: Record<string, string>): boolean {
+    const contentType = Object.entries(headers ?? {})
+      .filter(([key]) => key.toLowerCase() === CONTENT_TYPE_KEY)
+      .pop()?.[1];
+
+    return !!contentType?.toLowerCase().startsWith(PLAIN_TEXT_VALUE);
   }
 
   /**

--- a/packages/http-client-base/test/BaseHttpClient.test.ts
+++ b/packages/http-client-base/test/BaseHttpClient.test.ts
@@ -134,6 +134,46 @@ describe("BaseHttpClient Tests", () => {
     expect(mockClient.lastConfig).toStrictEqual(DEFAULT_CONFIG);
   });
 
+  /**
+   * Only a body which is explicitly declared as plain text is exempt from JSON serialization,
+   * see https://github.com/odata2ts/odata2ts/issues/383.
+   */
+  describe("isPlainTextBody", () => {
+    test("false without any headers or content type", () => {
+      expect(mockClient.checkPlainTextBody()).toBe(false);
+      expect(mockClient.checkPlainTextBody({})).toBe(false);
+      expect(mockClient.checkPlainTextBody({ Accept: JSON_VALUE })).toBe(false);
+    });
+
+    test("true for plain text", () => {
+      expect(mockClient.checkPlainTextBody({ "Content-Type": "text/plain" })).toBe(true);
+    });
+
+    test("true for plain text with charset", () => {
+      expect(mockClient.checkPlainTextBody({ "Content-Type": "text/plain; charset=utf-8" })).toBe(true);
+    });
+
+    test("false for any other content type", () => {
+      expect(mockClient.checkPlainTextBody({ "Content-Type": JSON_VALUE })).toBe(false);
+      expect(mockClient.checkPlainTextBody({ "Content-Type": "application/xml" })).toBe(false);
+      expect(mockClient.checkPlainTextBody({ "Content-Type": "image/png" })).toBe(false);
+    });
+
+    test("header name and value are matched case-insensitively", () => {
+      expect(mockClient.checkPlainTextBody({ "content-type": "text/plain" })).toBe(true);
+      expect(mockClient.checkPlainTextBody({ "CONTENT-TYPE": "TEXT/PLAIN" })).toBe(true);
+    });
+
+    /**
+     * The default JSON content type is only overridden by a differently spelled header, so both end up in
+     * the merged headers. The later one is the one which was meant to win.
+     */
+    test("the last of multiple content types wins", () => {
+      expect(mockClient.checkPlainTextBody({ "Content-Type": JSON_VALUE, "content-type": "text/plain" })).toBe(true);
+      expect(mockClient.checkPlainTextBody({ "content-type": "text/plain", "Content-Type": JSON_VALUE })).toBe(false);
+    });
+  });
+
   test("simple DELETE request", async () => {
     await mockClient.delete(DEFAULT_URL);
 

--- a/packages/http-client-base/test/MockHttpClient.ts
+++ b/packages/http-client-base/test/MockHttpClient.ts
@@ -42,6 +42,13 @@ export class MockHttpClient extends BaseHttpClient<MockRequestConfig> implements
     super(baseOptions);
   }
 
+  /**
+   * Exposes the protected method, which extending clients use to decide upon JSON serialization.
+   */
+  public checkPlainTextBody(headers?: Record<string, string>) {
+    return this.isPlainTextBody(headers);
+  }
+
   public exposedErrorMessageRetriever(errorResponse: any) {
     return this.retrieveErrorMessage(errorResponse);
   }

--- a/packages/jquery/src/JQueryClient.ts
+++ b/packages/jquery/src/JQueryClient.ts
@@ -59,7 +59,8 @@ export class JQueryClient extends BaseHttpClient<JQueryRequestConfig> implements
     const resultConfig: InternalRequestConfig = {
       ...mergedConfig,
       method,
-      data: JSON.stringify(data),
+      // only an explicitly plain text body is passed through as it is
+      data: this.isPlainTextBody(internalConfig.headers) ? data : JSON.stringify(data),
       url,
     };
 

--- a/packages/jquery/test/JQueryClient.test.ts
+++ b/packages/jquery/test/JQueryClient.test.ts
@@ -128,6 +128,19 @@ describe("JQueryClient Tests", function () {
     expect(getRequestData()).toBe(JSON.stringify(dataStructure));
   });
 
+  /**
+   * A plain text body goes over the wire as it is: JSON serializing it would wrap it into double quotes,
+   * which the server cannot parse. See https://github.com/odata2ts/odata2ts/issues/383.
+   */
+  test("post request with plain text body", async () => {
+    const query = "%24select=UserName&%24top=10";
+
+    await jqClient.post("", query, undefined, { "Content-Type": "text/plain" });
+
+    expect(getRequestData()).toBe(query);
+    expect(getRequestData()).not.toMatch(/^"/);
+  });
+
   test("put request", async () => {
     await jqClient.put(DEFAULT_URL, {});
 


### PR DESCRIPTION
Fixes the double quoting reported in https://github.com/odata2ts/odata2ts/issues/383.

- a request body declared via `Content-Type: text/plain` was serialized as JSON like any other, so `%24select=UserName` went over the wire as `"%24select=UserName"`, which the server cannot parse
- new protected method `isPlainTextBody` on the `BaseHttpClient`: matches the header name case-insensitively, and of multiple matches the last one wins - which is what the merged headers require, since a differently spelled override leaves both keys in place
- `FetchClient`: serializes as JSON only when the body is not plain text; blob and stream requests keep falling out via `dataType` as before
- `JQueryClient`: same decision instead of stringifying unconditionally
- `AxiosClient`: unchanged, it never had the bug because axios leaves strings alone - covered by a regression test now, so a future refactor cannot break it silently

This affects passing query options in the request body (`POST <resource>/$query`), offered by `asPostRequest()` of `@odata2ts/odata-service`.

Not included: `JQueryClient` also stringifies **Blob** bodies (`JSON.stringify(blob)` -> `"{}"`), so `createBlob`/`updateBlob` look broken there. Untouched here on purpose, since those paths never declare plain text - worth its own issue.

No integration test: no OData test service we have access to implements `$query`. The Trippin service answers `POST /People('russellwhyte')/$query` with 500 (`Value cannot be null. Parameter name: type`) for the correct body and the quoted one alike, so it cannot tell them apart - which is exactly why this went unnoticed. To be covered once we run our own test servers.
