### PR TITLE
chore: align release-please components with the package names

### DIFF
--- a/packages/axios/CHANGELOG.md
+++ b/packages/axios/CHANGELOG.md
@@ -6,39 +6,10 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ## [0.13.0](https://github.com/odata2ts/http-client/compare/@odata2ts/axios-v0.12.2...@odata2ts/axios-v0.13.0) (2026-07-31)
 
 
-### ⚠ BREAKING CHANGES
-
-* switch to ESM tends to break stuff
-* additional headers are now part of the config parameter
-* **axios:** removed default accept & content-type headers; removed merge & retrieveBigNumbersAsString methods (base-lib); all of these settings can now be configured per operation via the `additionalHeaders` option.
-* **axios:** new name and axios becomes peer dependency
-
-### Features
-
-* allow for additional headers for all operations ([#10](https://github.com/odata2ts/http-client/issues/10)) ([75eedd3](https://github.com/odata2ts/http-client/commit/75eedd3ebb8534188a5a644aee9e69e17f1f0c80))
-* **axios:** take over axios-odata-client as http-client-axios ([#1](https://github.com/odata2ts/http-client/issues/1)) ([d679f60](https://github.com/odata2ts/http-client/commit/d679f60087adfdefa00f2a4860bed77ca9b15654))
-* blob and stream support ([#12](https://github.com/odata2ts/http-client/issues/12)) ([ae6f062](https://github.com/odata2ts/http-client/commit/ae6f062371a0ad11707fa3f9edff9571998edb5b))
-* conventionalize client errors ([#5](https://github.com/odata2ts/http-client/issues/5)) ([a8e8912](https://github.com/odata2ts/http-client/commit/a8e89125eeda47436d48507d6a71efc90953f878))
-* create blob request ([#28](https://github.com/odata2ts/http-client/issues/28)) ([4cc238d](https://github.com/odata2ts/http-client/commit/4cc238d3fbe07c09d56732b4b12d0b1b875a3ef5))
-* switch to http-client-api ([52d1b86](https://github.com/odata2ts/http-client/commit/52d1b868ee82dbaf45486da6b22fdcf4c773dfb8))
-* switch to http-client-api ([5a6da23](https://github.com/odata2ts/http-client/commit/5a6da23053b3ea5adb866bb7e30b469f1b8ed260))
-
-
 ### Bug Fixes
 
-* add ".js" suffix for all relative imports ([#20](https://github.com/odata2ts/http-client/issues/20)) ([961c910](https://github.com/odata2ts/http-client/commit/961c91002c8b1e9a7a6256cccd6b6d0ec9c142cd))
-* always build all packages before release ([#26](https://github.com/odata2ts/http-client/issues/26)) ([a316f6c](https://github.com/odata2ts/http-client/commit/a316f6ce54c4360c8d6f87799ba6fd9c53bff52c))
-* delete requests with Accept json header ([ea1b06d](https://github.com/odata2ts/http-client/commit/ea1b06d509b490e1e899e96a62a10eac3f65da8e))
-* deploy with code ([#25](https://github.com/odata2ts/http-client/issues/25)) ([3e0e78c](https://github.com/odata2ts/http-client/commit/3e0e78cd2e0b0c3215bc0ed97dd62c75d8b6c5ea))
 * send a plain text request body as it is ([#35](https://github.com/odata2ts/http-client/issues/35)) ([2d44aff](https://github.com/odata2ts/http-client/commit/2d44aff43d4804070d53ea84dae271365bab4cf8))
 * update typescript to 6.0.3 and migrate to nodenext resolution ([f713098](https://github.com/odata2ts/http-client/commit/f71309861d7a58b7f0fb65cf8395f0262a932a9f))
-
-
-### Code Refactoring
-
-* **axios:** remove default headers ([7fcff0c](https://github.com/odata2ts/http-client/commit/7fcff0c8f1a0962abc60da84cde57e0469cc0bc2))
-* expand additionalHeaders param to internalConfig ([#15](https://github.com/odata2ts/http-client/issues/15)) ([7fe1d73](https://github.com/odata2ts/http-client/commit/7fe1d73a7436f64b84a060bd1dbf9e121ef901ce))
-* switch to vitest & ESM ([#18](https://github.com/odata2ts/http-client/issues/18)) ([748558f](https://github.com/odata2ts/http-client/commit/748558f1e3f699085ade1058b1459c843f60994f))
 
 
 ### Dependencies

--- a/packages/axios/CHANGELOG.md
+++ b/packages/axios/CHANGELOG.md
@@ -3,12 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @odata2ts/http-client-base bumped from ^0.5.5 to ^0.5.6
-
 ## [0.13.0](https://github.com/odata2ts/http-client/compare/@odata2ts/axios-v0.12.2...@odata2ts/axios-v0.13.0) (2026-07-31)
 
 
@@ -52,6 +46,15 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * The following workspace dependencies were updated
   * dependencies
     * @odata2ts/http-client-base bumped from ^0.5.6 to ^0.5.7
+
+## [0.12.2](https://github.com/odata2ts/http-client/compare/@odata2ts/axios-v0.12.1...@odata2ts/axios-v0.12.2) (2026-06-10)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @odata2ts/http-client-base bumped from ^0.5.5 to ^0.5.6
 
 ## [0.12.1](https://github.com/odata2ts/http-client/compare/@odata2ts/axios-v0.12.0...@odata2ts/axios-v0.12.1) (2026-06-10)
 

--- a/packages/fetch/CHANGELOG.md
+++ b/packages/fetch/CHANGELOG.md
@@ -3,18 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.8.0](https://github.com/odata2ts/http-client/compare/@odata2ts/http-client-fetch@0.7.2...@odata2ts/http-client-fetch@0.8.0) (2024-08-24)
-
-### Features
-
-* **fetch:** FetchClientError with full responseData object ([#22](https://github.com/odata2ts/http-client/issues/22)) ([e66fa95](https://github.com/odata2ts/http-client/commit/e66fa952909383d55555eed23d1a8e55fe0081f2))
-
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @odata2ts/http-client-base bumped from ^0.5.5 to ^0.5.6
-
 ## [0.10.0](https://github.com/odata2ts/http-client/compare/@odata2ts/fetch-v0.9.2...@odata2ts/fetch-v0.10.0) (2026-07-31)
 
 
@@ -59,6 +47,15 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * The following workspace dependencies were updated
   * dependencies
     * @odata2ts/http-client-base bumped from ^0.5.6 to ^0.5.7
+
+## [0.9.2](https://github.com/odata2ts/http-client/compare/@odata2ts/fetch-v0.9.1...@odata2ts/fetch-v0.9.2) (2026-06-10)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @odata2ts/http-client-base bumped from ^0.5.5 to ^0.5.6
 
 ## [0.9.1](https://github.com/odata2ts/http-client/compare/@odata2ts/fetch-v0.9.0...@odata2ts/fetch-v0.9.1) (2026-06-10)
 
@@ -115,6 +112,12 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * The following workspace dependencies were updated
   * dependencies
     * @odata2ts/http-client-base bumped from ^0.5.3 to ^0.5.4
+
+# [0.8.0](https://github.com/odata2ts/http-client/compare/@odata2ts/http-client-fetch@0.7.2...@odata2ts/http-client-fetch@0.8.0) (2024-08-24)
+
+### Features
+
+* **fetch:** FetchClientError with full responseData object ([#22](https://github.com/odata2ts/http-client/issues/22)) ([e66fa95](https://github.com/odata2ts/http-client/commit/e66fa952909383d55555eed23d1a8e55fe0081f2))
 
 ## [0.7.2](https://github.com/odata2ts/http-client/compare/@odata2ts/http-client-fetch@0.7.1...@odata2ts/http-client-fetch@0.7.2) (2024-08-22)
 

--- a/packages/fetch/CHANGELOG.md
+++ b/packages/fetch/CHANGELOG.md
@@ -6,40 +6,10 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ## [0.10.0](https://github.com/odata2ts/http-client/compare/@odata2ts/fetch-v0.9.2...@odata2ts/fetch-v0.10.0) (2026-07-31)
 
 
-### ⚠ BREAKING CHANGES
-
-* switch to ESM tends to break stuff
-* additional headers are now part of the config parameter
-* **fetch:** removed default accept & content-type headers; removed merge & retrieveBigNumbersAsString methods (base-lib); all of these settings can now be configured per operation via the `additionalHeaders` option.
-
-### Features
-
-* allow for additional headers for all operations ([#10](https://github.com/odata2ts/http-client/issues/10)) ([75eedd3](https://github.com/odata2ts/http-client/commit/75eedd3ebb8534188a5a644aee9e69e17f1f0c80))
-* blob and stream support ([#12](https://github.com/odata2ts/http-client/issues/12)) ([ae6f062](https://github.com/odata2ts/http-client/commit/ae6f062371a0ad11707fa3f9edff9571998edb5b))
-* conventionalize client errors ([#5](https://github.com/odata2ts/http-client/issues/5)) ([a8e8912](https://github.com/odata2ts/http-client/commit/a8e89125eeda47436d48507d6a71efc90953f878))
-* create blob request ([#28](https://github.com/odata2ts/http-client/issues/28)) ([4cc238d](https://github.com/odata2ts/http-client/commit/4cc238d3fbe07c09d56732b4b12d0b1b875a3ef5))
-* **fetch:** allow for query params ([#13](https://github.com/odata2ts/http-client/issues/13)) ([1507ed1](https://github.com/odata2ts/http-client/commit/1507ed13c2020de051827db516ae1fc9c7f4b0ac))
-* **fetch:** FetchClientError with full responseData object ([#22](https://github.com/odata2ts/http-client/issues/22)) ([e66fa95](https://github.com/odata2ts/http-client/commit/e66fa952909383d55555eed23d1a8e55fe0081f2))
-* **fetch:** full fetch client implementation ([a8e5fb7](https://github.com/odata2ts/http-client/commit/a8e5fb73594cf2d446eefc69e77b8b5e4bcae1ca))
-* switch to http-client-api ([52d1b86](https://github.com/odata2ts/http-client/commit/52d1b868ee82dbaf45486da6b22fdcf4c773dfb8))
-* switch to http-client-api ([5a6da23](https://github.com/odata2ts/http-client/commit/5a6da23053b3ea5adb866bb7e30b469f1b8ed260))
-
-
 ### Bug Fixes
 
-* add ".js" suffix for all relative imports ([#20](https://github.com/odata2ts/http-client/issues/20)) ([961c910](https://github.com/odata2ts/http-client/commit/961c91002c8b1e9a7a6256cccd6b6d0ec9c142cd))
-* always build all packages before release ([#26](https://github.com/odata2ts/http-client/issues/26)) ([a316f6c](https://github.com/odata2ts/http-client/commit/a316f6ce54c4360c8d6f87799ba6fd9c53bff52c))
-* delete requests with Accept json header ([ea1b06d](https://github.com/odata2ts/http-client/commit/ea1b06d509b490e1e899e96a62a10eac3f65da8e))
-* deploy with code ([#25](https://github.com/odata2ts/http-client/issues/25)) ([3e0e78c](https://github.com/odata2ts/http-client/commit/3e0e78cd2e0b0c3215bc0ed97dd62c75d8b6c5ea))
 * send a plain text request body as it is ([#35](https://github.com/odata2ts/http-client/issues/35)) ([2d44aff](https://github.com/odata2ts/http-client/commit/2d44aff43d4804070d53ea84dae271365bab4cf8))
 * update typescript to 6.0.3 and migrate to nodenext resolution ([f713098](https://github.com/odata2ts/http-client/commit/f71309861d7a58b7f0fb65cf8395f0262a932a9f))
-
-
-### Code Refactoring
-
-* expand additionalHeaders param to internalConfig ([#15](https://github.com/odata2ts/http-client/issues/15)) ([7fe1d73](https://github.com/odata2ts/http-client/commit/7fe1d73a7436f64b84a060bd1dbf9e121ef901ce))
-* **fetch:** remove default headers ([39bea92](https://github.com/odata2ts/http-client/commit/39bea92a2b8335af8a1588a4156974fcbd5ae417))
-* switch to vitest & ESM ([#18](https://github.com/odata2ts/http-client/issues/18)) ([748558f](https://github.com/odata2ts/http-client/commit/748558f1e3f699085ade1058b1459c843f60994f))
 
 
 ### Dependencies

--- a/packages/jquery/CHANGELOG.md
+++ b/packages/jquery/CHANGELOG.md
@@ -6,42 +6,11 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ## [0.12.0](https://github.com/odata2ts/http-client/compare/@odata2ts/jquery-v0.11.1...@odata2ts/jquery-v0.12.0) (2026-07-31)
 
 
-### ⚠ BREAKING CHANGES
-
-* **jquery:** AjaxRequestConfig becomes JQueryRequestConfig
-* switch to ESM tends to break stuff
-* additional headers are now part of the config parameter
-* **jquery:** removed default accept & content-type headers as well as `dataType=json`; removed merge & retrieveBigNumbersAsString methods (base-lib); all of these settings can now be configured per operation via the `additionalHeaders` option.
-
-### Features
-
-* allow for additional headers for all operations ([#10](https://github.com/odata2ts/http-client/issues/10)) ([75eedd3](https://github.com/odata2ts/http-client/commit/75eedd3ebb8534188a5a644aee9e69e17f1f0c80))
-* blob and stream support ([#12](https://github.com/odata2ts/http-client/issues/12)) ([ae6f062](https://github.com/odata2ts/http-client/commit/ae6f062371a0ad11707fa3f9edff9571998edb5b))
-* conventionalize client errors ([#5](https://github.com/odata2ts/http-client/issues/5)) ([a8e8912](https://github.com/odata2ts/http-client/commit/a8e89125eeda47436d48507d6a71efc90953f878))
-* create blob request ([#28](https://github.com/odata2ts/http-client/issues/28)) ([4cc238d](https://github.com/odata2ts/http-client/commit/4cc238d3fbe07c09d56732b4b12d0b1b875a3ef5))
-* **jquery:** allow for query params ([afd13a8](https://github.com/odata2ts/http-client/commit/afd13a862dc07485c0f619a3e39521f7ce6fc65e))
-* **jquery:** copy over jquery-client and rename ([#3](https://github.com/odata2ts/http-client/issues/3)) ([55deb6c](https://github.com/odata2ts/http-client/commit/55deb6c75159bfc46b0ae87cb3c0ec3afda9508e))
-* switch to http-client-api ([52d1b86](https://github.com/odata2ts/http-client/commit/52d1b868ee82dbaf45486da6b22fdcf4c773dfb8))
-* switch to http-client-api ([5a6da23](https://github.com/odata2ts/http-client/commit/5a6da23053b3ea5adb866bb7e30b469f1b8ed260))
-
-
 ### Bug Fixes
 
-* add ".js" suffix for all relative imports ([#20](https://github.com/odata2ts/http-client/issues/20)) ([961c910](https://github.com/odata2ts/http-client/commit/961c91002c8b1e9a7a6256cccd6b6d0ec9c142cd))
-* always build all packages before release ([#26](https://github.com/odata2ts/http-client/issues/26)) ([a316f6c](https://github.com/odata2ts/http-client/commit/a316f6ce54c4360c8d6f87799ba6fd9c53bff52c))
-* delete requests with Accept json header ([ea1b06d](https://github.com/odata2ts/http-client/commit/ea1b06d509b490e1e899e96a62a10eac3f65da8e))
-* deploy with code ([#25](https://github.com/odata2ts/http-client/issues/25)) ([3e0e78c](https://github.com/odata2ts/http-client/commit/3e0e78cd2e0b0c3215bc0ed97dd62c75d8b6c5ea))
-* **http-client-jquery:** stop pinning an external image's exact byte size ([fb3fece](https://github.com/odata2ts/http-client/commit/fb3fece1b5d39459acdd69d0d3c37798641a2288))
 * send a plain text request body as it is ([#35](https://github.com/odata2ts/http-client/issues/35)) ([2d44aff](https://github.com/odata2ts/http-client/commit/2d44aff43d4804070d53ea84dae271365bab4cf8))
 * update typescript to 6.0.3 and migrate to nodenext resolution ([f713098](https://github.com/odata2ts/http-client/commit/f71309861d7a58b7f0fb65cf8395f0262a932a9f))
-
-
-### Code Refactoring
-
-* expand additionalHeaders param to internalConfig ([#15](https://github.com/odata2ts/http-client/issues/15)) ([7fe1d73](https://github.com/odata2ts/http-client/commit/7fe1d73a7436f64b84a060bd1dbf9e121ef901ce))
-* **jquery:** benefit from api additions & improve config handling ([d08e4f3](https://github.com/odata2ts/http-client/commit/d08e4f30140d4c1d8968c71b89c9eb009ab44a93))
-* **jquery:** remove default headers ([3106d97](https://github.com/odata2ts/http-client/commit/3106d9768765e7cc228097ed1270439d47ff0e0c))
-* switch to vitest & ESM ([#18](https://github.com/odata2ts/http-client/issues/18)) ([748558f](https://github.com/odata2ts/http-client/commit/748558f1e3f699085ade1058b1459c843f60994f))
+* **http-client-jquery:** stop pinning an external image's exact byte size ([fb3fece](https://github.com/odata2ts/http-client/commit/fb3fece1b5d39459acdd69d0d3c37798641a2288))
 
 
 ### Dependencies

--- a/packages/jquery/CHANGELOG.md
+++ b/packages/jquery/CHANGELOG.md
@@ -3,12 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-### Dependencies
-
-* The following workspace dependencies were updated
-  * dependencies
-    * @odata2ts/http-client-base bumped from ^0.5.5 to ^0.5.6
-
 ## [0.12.0](https://github.com/odata2ts/http-client/compare/@odata2ts/jquery-v0.11.1...@odata2ts/jquery-v0.12.0) (2026-07-31)
 
 
@@ -55,6 +49,15 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * The following workspace dependencies were updated
   * dependencies
     * @odata2ts/http-client-base bumped from ^0.5.6 to ^0.5.7
+
+## [0.11.1](https://github.com/odata2ts/http-client/compare/@odata2ts/jquery-v0.11.0...@odata2ts/jquery-v0.11.1) (2026-06-10)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @odata2ts/http-client-base bumped from ^0.5.5 to ^0.5.6
 
 ## [0.11.0](https://github.com/odata2ts/http-client/compare/@odata2ts/jquery-v0.10.0...@odata2ts/jquery-v0.11.0) (2026-06-10)
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -21,13 +21,13 @@
       "component": "@odata2ts/http-client-base"
     },
     "packages/axios": {
-      "component": "@odata2ts/axios"
+      "component": "@odata2ts/http-client-axios"
     },
     "packages/fetch": {
-      "component": "@odata2ts/fetch"
+      "component": "@odata2ts/http-client-fetch"
     },
     "packages/jquery": {
-      "component": "@odata2ts/jquery"
+      "component": "@odata2ts/http-client-jquery"
     }
   }
 }


### PR DESCRIPTION
Cleans up after the release of #35, whose notes for axios, fetch and jquery replayed the entire history of the repository instead of the actual change.

**Cause**: with `include-component-in-tag`, release-please determines what is new by looking for the tag `<component>-v<version from the manifest>`. The manifest claimed axios 0.12.2, fetch 0.9.2 and jquery 0.11.1, but those tags never existed - the 2026-06-10 run published them to npm and advanced the manifest, yet neither tagged them nor gave their changelog entry a version heading. Without that anchor release-please walks back to the very first commit, which is why the notes listed everything since PR #1 and why ancient `BREAKING CHANGE` footers produced a minor bump for a patch-level fix. `http-client-api` and `http-client-base` were unaffected, their tags were in place.

**Changes**

- components now match the actual package names: `@odata2ts/axios|fetch|jquery` -> `@odata2ts/http-client-axios|fetch|jquery`. Until now tags and GitHub releases carried a name which does not exist on npm.
- tags created for the current versions under the new component names, so the anchor survives the rename - `@odata2ts/http-client-axios-v0.13.0`, `@odata2ts/http-client-fetch-v0.10.0`, `@odata2ts/http-client-jquery-v0.12.0`. Renaming the components without these would have re-triggered the very bug this fixes.
- the missing 0.12.2 / 0.9.2 / 0.11.1 entries get their version heading, and the corresponding tags are created at the release commit `ff2a411`, so the compare links resolve.
- the 0.8.0 section of the fetch changelog moves from the top of the file to its chronological place; it had been left behind by the earlier renaming.

No source code is touched, so nothing needs to be published for this.
