### PR TITLE
fix(http-client-jquery): send binary data as it is

### DIFF
--- a/packages/jquery/src/JQueryClient.ts
+++ b/packages/jquery/src/JQueryClient.ts
@@ -15,8 +15,9 @@ import jqXHR = JQuery.jqXHR;
 export const DEFAULT_ERROR_MESSAGE = "No error message!";
 
 interface InternalRequestConfig
-  extends JQueryRequestConfig,
-    Pick<JQuery.AjaxSettings, "url" | "data" | "dataType" | "method" | "xhrFields"> {}
+  extends
+    JQueryRequestConfig,
+    Pick<JQuery.AjaxSettings, "url" | "data" | "dataType" | "method" | "xhrFields" | "processData" | "contentType"> {}
 
 export class JQueryClient extends BaseHttpClient<JQueryRequestConfig> implements ODataHttpClient<JQueryRequestConfig> {
   private readonly client: JQueryStatic;
@@ -54,13 +55,14 @@ export class JQueryClient extends BaseHttpClient<JQueryRequestConfig> implements
   ): Promise<HttpResponseModel<ResponseModel>> {
     const { headers } = internalConfig;
     const { params, ...mergedConfig } = mergeConfigs(this.config, mergeConfigs({ headers }, requestConfig));
+    const isBinary = internalConfig.dataType === "blob";
 
     // set core inputs for request
     const resultConfig: InternalRequestConfig = {
       ...mergedConfig,
       method,
-      // only an explicitly plain text body is passed through as it is
-      data: this.isPlainTextBody(internalConfig.headers) ? data : JSON.stringify(data),
+      // only binary data and an explicitly plain text body are passed through as they are
+      data: isBinary || this.isPlainTextBody(internalConfig.headers) ? data : JSON.stringify(data),
       url,
     };
 
@@ -73,8 +75,12 @@ export class JQueryClient extends BaseHttpClient<JQueryRequestConfig> implements
     }
 
     // handling of extra data types: blob and stream (not supported)
-    if (internalConfig.dataType === "blob") {
+    if (isBinary) {
       resultConfig.xhrFields = { responseType: "blob" };
+      // jQuery would otherwise turn the blob into a query string (processData defaults to true)
+      // and add its own urlencoded content type; the actual mime type is already part of the headers
+      resultConfig.processData = false;
+      resultConfig.contentType = false;
     } else if (internalConfig.dataType === "stream") {
       throw new Error("Streaming is not supported by the JqueryClient!");
     }

--- a/packages/jquery/test/BlobHandling.test.ts
+++ b/packages/jquery/test/BlobHandling.test.ts
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+
+import jquery from "jquery";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { JQueryClient } from "../src";
+
+const DEFAULT_URL = "/test/blob";
+const MIME_TYPE = "text/csv";
+const CONTENT = "hello world";
+
+interface SentRequest {
+  method: string;
+  url: string;
+  headers: Record<string, string>;
+  body: any;
+}
+
+let sentRequest: SentRequest;
+
+/**
+ * Minimal XHR replacement which records the request and answers with 204.
+ */
+class XhrRecorder {
+  private method: string = "";
+  private url: string = "";
+  private readonly headers: Record<string, string> = {};
+
+  public readyState = 4;
+  public status = 204;
+  public statusText = "No Content";
+  public response: any = undefined;
+  public responseText = "";
+  public onload: (() => void) | null = null;
+  public onerror: (() => void) | null = null;
+  public onabort: (() => void) | null = null;
+  public ontimeout: (() => void) | null = null;
+  public onreadystatechange: (() => void) | null = null;
+
+  public open(method: string, url: string) {
+    this.method = method;
+    this.url = url;
+  }
+
+  public setRequestHeader(name: string, value: string) {
+    this.headers[name] = value;
+  }
+
+  public getAllResponseHeaders() {
+    return "";
+  }
+
+  public abort() {}
+
+  public send(body: any) {
+    sentRequest = { method: this.method, url: this.url, headers: this.headers, body };
+    this.onload?.();
+  }
+}
+
+/**
+ * Binary uploads only work if the blob is handed to jQuery untouched: JSON serializing it would yield "{}",
+ * while jQuery's processData (true by default) would turn it into a query string.
+ * Hence these tests exercise the real jQuery, mocking out only the XHR itself.
+ *
+ * See https://github.com/odata2ts/odata2ts/issues/421.
+ */
+describe("Blob Handling Tests", function () {
+  const originalXhr = window.XMLHttpRequest;
+  let jqClient: JQueryClient;
+
+  beforeEach(() => {
+    // @ts-ignore: only the parts jQuery actually uses are implemented
+    window.XMLHttpRequest = XhrRecorder;
+    jqClient = new JQueryClient(jquery);
+  });
+
+  afterEach(() => {
+    window.XMLHttpRequest = originalXhr;
+  });
+
+  test("create blob", async () => {
+    const blob = new Blob([CONTENT], { type: MIME_TYPE });
+
+    await jqClient.createBlob(DEFAULT_URL, blob, MIME_TYPE);
+
+    expect(sentRequest.method).toBe("POST");
+    expect(sentRequest.headers["Content-Type"]).toBe(MIME_TYPE);
+    expect(sentRequest.body).toBe(blob);
+    await expect(sentRequest.body.text()).resolves.toBe(CONTENT);
+  });
+
+  test("update blob", async () => {
+    const blob = new Blob([CONTENT], { type: MIME_TYPE });
+
+    await jqClient.updateBlob(DEFAULT_URL, blob, MIME_TYPE);
+
+    expect(sentRequest.method).toBe("PUT");
+    expect(sentRequest.url).toMatch(DEFAULT_URL);
+    expect(sentRequest.headers["Content-Type"]).toBe(MIME_TYPE);
+    expect(sentRequest.body).toBe(blob);
+    await expect(sentRequest.body.text()).resolves.toBe(CONTENT);
+  });
+
+  test("regular request still gets serialized as JSON", async () => {
+    const data = { test: "hey", collection: [{ hey: 3 }] };
+
+    await jqClient.post(DEFAULT_URL, data);
+
+    expect(sentRequest.headers["Content-Type"]).toBe("application/json");
+    expect(sentRequest.body).toBe(JSON.stringify(data));
+  });
+});

--- a/packages/jquery/test/JQueryClient.test.ts
+++ b/packages/jquery/test/JQueryClient.test.ts
@@ -201,11 +201,41 @@ describe("JQueryClient Tests", function () {
     expect(getRequestHeaders()).toStrictEqual({});
   });
 
+  /**
+   * Binary data must reach the server as it is: JSON serializing a blob would yield "{}", while jQuery's
+   * processData would turn it into a query string. See https://github.com/odata2ts/odata2ts/issues/421.
+   */
+  test("create blob request", async () => {
+    const mimeType = "text/csv";
+    const blob = new Blob(["hello world"], { type: mimeType });
+
+    await jqClient.createBlob(DEFAULT_URL, blob, mimeType);
+
+    expect(getRequestData()).toBe(blob);
+    expect(getRequestDetails()).toMatchObject({
+      url: DEFAULT_URL,
+      method: "POST",
+      xhrFields: { responseType: "blob" },
+      processData: false,
+      contentType: false,
+    });
+    expect(getRequestHeaders()).toStrictEqual({ Accept: JSON_VALUE, "Content-Type": mimeType });
+  });
+
   test("update blob request", async () => {
     const mimeType = "image/jpg";
-    await jqClient.updateBlob(DEFAULT_URL, new Blob(), mimeType);
+    const blob = new Blob([new Uint8Array([1, 2, 3])], { type: mimeType });
 
-    expect(getRequestDetails()).toMatchObject({ url: DEFAULT_URL, method: "PUT", xhrFields: { responseType: "blob" } });
+    await jqClient.updateBlob(DEFAULT_URL, blob, mimeType);
+
+    expect(getRequestData()).toBe(blob);
+    expect(getRequestDetails()).toMatchObject({
+      url: DEFAULT_URL,
+      method: "PUT",
+      xhrFields: { responseType: "blob" },
+      processData: false,
+      contentType: false,
+    });
     expect(getRequestHeaders()).toStrictEqual({ Accept: JSON_VALUE, "Content-Type": mimeType });
   });
 


### PR DESCRIPTION
- pass a binary request body (`dataType: blob`) through to jQuery as it is instead of JSON serializing it: `JSON.stringify(blob)` yields `"{}"`, so `createBlob` and `updateBlob` never transmitted their payload
- set `processData: false` for those requests, since jQuery would otherwise convert the blob into a query string (`processData` defaults to `true`)
- set `contentType: false` alongside, so jQuery does not add its urlencoded default content type; the actual mime type already comes in via the headers, which jQuery applies last
- assert the transmitted `data` in the blob tests (the existing `update blob request` test only looked at url, method and headers, `createBlob` had no test at all)
- add `BlobHandling.test.ts`, which drives the real jQuery in jsdom with only the XHR stubbed out, thereby pinning what actually reaches `xhr.send()` — the `processData` part cannot be covered by config level assertions alone

Only the jQuery client was affected: the `FetchClient` decides via `dataType`, the `AxiosClient` hands the body over untouched.

Closes https://github.com/odata2ts/odata2ts/issues/421