### PR TITLE
fix(http-client-base): repeat the identical request after token expiration

### DIFF
--- a/packages/http-client-base/src/BaseHttpClient.ts
+++ b/packages/http-client-base/src/BaseHttpClient.ts
@@ -183,9 +183,11 @@ export abstract class BaseHttpClient<RequestConfigType> {
         !!clientError.headers &&
         clientError.headers["x-csrf-token"] === "Required"
       ) {
-        // token has expired: reset csrf token & perform the original request again
+        // token has expired: reset csrf token & perform the original request again;
+        // the internal config must be handed over as well, otherwise the repeated request would lose
+        // its headers (content type!) and its data type
         this.csrfToken = undefined;
-        return this.sendRequest<ResponseModel>(method, url, data, requestConfig);
+        return this.sendRequest<ResponseModel>(method, url, data, requestConfig, internalConfig);
       }
 
       throw e;

--- a/packages/http-client-base/test/CsrfTokenHandling.test.ts
+++ b/packages/http-client-base/test/CsrfTokenHandling.test.ts
@@ -58,6 +58,33 @@ describe("CSRF Token Handling Tests", () => {
     expect(token).not.toBe(token2);
   });
 
+  /**
+   * The repeated request must be the identical one: losing the internal config would strip the headers
+   * (content type!) and the data type, whereby e.g. a blob would no longer be recognized as binary data.
+   */
+  test("token expiration retains internal config", async () => {
+    const mimeType = "text/csv";
+    const blob = new Blob(["hello world"], { type: mimeType });
+    const requestConfig = { x: "y" };
+
+    // the first request caches the token, the second one runs into its expiration
+    await mockClient.post("test", {});
+    mockClient.simulateTokenExpired = true;
+    await mockClient.updateBlob("test", blob, mimeType, requestConfig, { hey: "ho" });
+
+    expect(mockClient.lastData).toBe(blob);
+    expect(mockClient.lastConfig).toStrictEqual(requestConfig);
+    expect(mockClient.lastInternalConfig).toMatchObject({
+      dataType: "blob",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": mimeType,
+        hey: "ho",
+        [mockClient.getCsrfTokenKey()]: mockClient.generatedCsrfToken!,
+      },
+    });
+  });
+
   test("set token key", async () => {
     expect(mockClient.getCsrfTokenKey()).toBe("x-csrf-token");
     mockClient.setCsrfTokenKey("");


### PR DESCRIPTION
- hand the internal request config over to the retry which `sendRequest` performs after an expired CSRF token: it was dropped so far, whereby the repeated request lost all internal headers (`Accept`, `Content-Type` resp. the mime type of a blob, plus any additional headers of the caller) as well as its `dataType`
- consequently a retried POST / PUT / PATCH went out without a content type, and a retried `createBlob` / `updateBlob` was no longer recognized as binary data by the clients - in the JQueryClient the blob would have been JSON serialized to `{}` again, i.e. the very bug of https://github.com/odata2ts/odata2ts/issues/421 (fixed for the regular path by #37)
- pin it: the CSRF tests only asserted that a new token is fetched, never that the repeated request is still the original one

Noticed while fixing #37.