### PR TITLE
fix(http-client-axios)!: refuse binary responses instead of faking them

### DIFF
--- a/packages/axios/README.md
+++ b/packages/axios/README.md
@@ -9,6 +9,18 @@ It supports:
 
 - request configuration
 - automatic CSRF token handling
+- uploading binary data (`createBlob` / `updateBlob`)
+
+It does **not** support:
+
+- **streaming** (`getStream`): axios' XHR adapter cannot stream at all, and its http adapter yields a
+  Node.js stream rather than a `ReadableStream`. The call is refused with an error.
+- **binary responses outside the browser** (`getBlob`, and a write answering with the stored content):
+  without `XMLHttpRequest` axios falls back to its http adapter, which decodes the response as text, so
+  a `Blob` can never be delivered. Refused with an error instead of handing back a string that only
+  claims to be a `Blob`.
+
+Use the [Fetch Client](https://www.npmjs.com/package/@odata2ts/http-client-fetch) if you need either.
 
 ## Installation
 

--- a/packages/axios/src/AxiosClient.ts
+++ b/packages/axios/src/AxiosClient.ts
@@ -22,14 +22,39 @@ const FAILURE_NO_REQUEST = "No request was sent! Failure: ";
 const FAILURE_RESPONSE_MESSAGE = "OData server responded with error: ";
 const FAILURE_AXIOS = "Fatal Axios failure: ";
 
+export const FAILURE_STREAM_UNSUPPORTED =
+  "Streaming is not supported by the AxiosClient! Its XHR adapter cannot stream at all, and its http " +
+  "adapter yields a Node.js stream instead of a ReadableStream. Use the FetchClient for streams.";
+export const FAILURE_BLOB_UNSUPPORTED =
+  "Binary responses are not supported by the AxiosClient outside the browser! Without XMLHttpRequest " +
+  "axios falls back to its http adapter, which decodes the response as text - so a Blob can never be " +
+  "delivered. Use the FetchClient for binary data.";
+
 function buildErrorMessage(prefix: string, error: any) {
   const msg = typeof error === "string" ? error : (error as Error)?.message;
   return prefix + (msg || DEFAULT_ERROR_MESSAGE);
 }
 
+/**
+ * Whether axios will use its XHR adapter, which is the only one of the two that can deliver a `Blob`.
+ *
+ * Asked as a question about the environment rather than about the configured adapter on purpose: axios
+ * picks the adapter itself, and the presence of `XMLHttpRequest` is exactly what that choice comes down
+ * to. Without it the http adapter takes over and hands back a string, which is the failure this guards.
+ */
+function hasBinaryCapableAdapter(): boolean {
+  return typeof XMLHttpRequest !== "undefined";
+}
+
+/**
+ * Whether the response carried no body worth looking at - 204 leaves axios with an empty string.
+ */
+function isEmpty(data: unknown): boolean {
+  return data === undefined || data === null || data === "";
+}
+
 interface InternalRequestConfig
-  extends AxiosRequestConfig,
-    Pick<OriginalRequestConfig, "method" | "url" | "responseType"> {}
+  extends AxiosRequestConfig, Pick<OriginalRequestConfig, "method" | "url" | "responseType"> {}
 
 export class AxiosClient extends BaseHttpClient<AxiosRequestConfig> implements ODataHttpClient<AxiosRequestConfig> {
   protected readonly client: AxiosInstance;
@@ -61,8 +86,24 @@ export class AxiosClient extends BaseHttpClient<AxiosRequestConfig> implements O
       resultConfig.responseType = internalConfig.dataType;
     }
 
+    /*
+     * Refuse what this client cannot deliver, instead of returning something that merely looks like it.
+     * Passing `responseType` through was silently wrong: `stream` yielded a Node.js stream where the API
+     * declares a `ReadableStream`, and `blob` a plain string where it declares a `Blob`. Both satisfy the
+     * compiler and fail at the first `.text()` or `.getReader()` - far away from the cause.
+     */
+    if (internalConfig.dataType === ODataHttpDataTypes.STREAM) {
+      throw new AxiosClientError(FAILURE_STREAM_UNSUPPORTED);
+    }
+    // Sending binary data works on either adapter, so only a request expecting binary *back* is refused
+    // up front; a write is checked afterwards, once it is known whether a body came back at all.
+    if (internalConfig.dataType === ODataHttpDataTypes.BLOB && !hasBinaryCapableAdapter() && data === undefined) {
+      throw new AxiosClientError(FAILURE_BLOB_UNSUPPORTED);
+    }
+
+    let response: HttpResponseModel<ResponseModel>;
     try {
-      return await this.client.request(resultConfig);
+      response = await this.client.request(resultConfig);
     } catch (error: any) {
       if ((error as AxiosError).isAxiosError) {
         const axiosError = error as AxiosError;
@@ -93,6 +134,14 @@ export class AxiosClient extends BaseHttpClient<AxiosRequestConfig> implements O
       // not an Axios error
       throw new AxiosClientError(buildErrorMessage(FAILURE_AXIOS, error), undefined, undefined, error);
     }
+
+    // A write may answer with the stored content, which runs into the same wall a read would: checked
+    // here rather than up front, because the usual answer is 204 and that case is perfectly fine.
+    if (internalConfig.dataType === ODataHttpDataTypes.BLOB && !hasBinaryCapableAdapter() && !isEmpty(response.data)) {
+      throw new AxiosClientError(FAILURE_BLOB_UNSUPPORTED, response.status, response.headers);
+    }
+
+    return response;
   }
 
   protected mapHeaders(headers: AxiosResponseHeaders | RawAxiosResponseHeaders): Record<string, string> {

--- a/packages/axios/test/AxiosODataClient.test.ts
+++ b/packages/axios/test/AxiosODataClient.test.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosResponse, CreateAxiosDefaults, AxiosRequestConfig as OriginalRequestConfig } from "axios";
-import { beforeEach, describe, expect, test, vi } from "vitest";
-import { AxiosClient, AxiosRequestConfig } from "../src";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { AxiosClient, AxiosRequestConfig, FAILURE_BLOB_UNSUPPORTED, FAILURE_STREAM_UNSUPPORTED } from "../src";
 
 const DEFAULT_URL = "TEST/hi";
 const JSON_VALUE = "application/json";
@@ -182,39 +182,86 @@ describe("Axios HTTP Client Tests", function () {
     expect(response.data).toBeUndefined();
   });
 
-  test("get blob request", async () => {
-    await axiosClient.getBlob(DEFAULT_URL);
+  /**
+   * Binary data is the one area where the two axios adapters differ in what they can deliver at all, so
+   * these tests state which environment they are in: `XMLHttpRequest` is what axios picks the adapter by.
+   * Vitest runs in Node here, hence no XHR unless a test stubs one in.
+   */
+  describe("binary data", () => {
+    const blobHeaders = { Accept: JSON_VALUE, "Content-Type": "image/jpg" };
 
-    expect(requestConfig).toStrictEqual({
-      url: DEFAULT_URL,
-      headers: undefined,
-      responseType: "blob",
-      method: "GET",
+    function simulateBrowser() {
+      vi.stubGlobal("XMLHttpRequest", class {});
+    }
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
     });
-  });
 
-  test("update blob request", async () => {
-    const data = new Blob(["a"]);
-    const mimeType = "image/jpg";
-    await axiosClient.updateBlob(DEFAULT_URL, data, mimeType);
+    test("get blob request in the browser", async () => {
+      simulateBrowser();
 
-    expect(requestConfig).toStrictEqual({
-      url: DEFAULT_URL,
-      headers: { Accept: JSON_VALUE, "Content-Type": mimeType },
-      method: "PUT",
-      responseType: "blob",
-      data,
+      await axiosClient.getBlob(DEFAULT_URL);
+
+      expect(requestConfig).toStrictEqual({
+        url: DEFAULT_URL,
+        headers: undefined,
+        responseType: "blob",
+        method: "GET",
+      });
     });
-  });
 
-  test("stream request not supported", async () => {
-    await axiosClient.getStream(DEFAULT_URL);
+    test("get blob request is refused without XMLHttpRequest", async () => {
+      // The http adapter decodes the response as text, so it would hand back a string where the API
+      // declares a Blob - a lie the compiler cannot catch, hence the refusal.
+      await expect(axiosClient.getBlob(DEFAULT_URL)).rejects.toThrow(FAILURE_BLOB_UNSUPPORTED);
+      expect(requestConfig).toBeUndefined();
+    });
 
-    expect(requestConfig).toStrictEqual({
-      url: DEFAULT_URL,
-      headers: undefined,
-      method: "GET",
-      responseType: "stream",
+    test("update blob request in the browser", async () => {
+      simulateBrowser();
+      const data = new Blob(["a"]);
+
+      await axiosClient.updateBlob(DEFAULT_URL, data, "image/jpg");
+
+      expect(requestConfig).toStrictEqual({
+        url: DEFAULT_URL,
+        headers: blobHeaders,
+        method: "PUT",
+        responseType: "blob",
+        data,
+      });
+    });
+
+    test("uploading a blob works without XMLHttpRequest, as long as nothing binary comes back", async () => {
+      // Sending is fine on either adapter, and the usual answer is 204 - refusing this would break a
+      // working upload path for Node users.
+      simulateNoContent = true;
+      const data = new Blob(["a"]);
+
+      const response = await axiosClient.updateBlob(DEFAULT_URL, data, "image/jpg");
+
+      expect(response.status).toBe(204);
+      expect(requestConfig).toMatchObject({ method: "PUT", responseType: "blob", data });
+    });
+
+    test("a blob coming back from a write is refused without XMLHttpRequest", async () => {
+      // Here the server does answer with content: that response can only be a string, so it is refused
+      // rather than passed on as a pseudo-Blob.
+      await expect(axiosClient.updateBlob(DEFAULT_URL, new Blob(["a"]), "image/jpg")).rejects.toThrow(
+        FAILURE_BLOB_UNSUPPORTED,
+      );
+    });
+
+    test("streaming is refused in either environment", async () => {
+      // Not an environment question at all: the XHR adapter cannot stream, and the http adapter returns a
+      // Node.js stream where the API declares a ReadableStream.
+      await expect(axiosClient.getStream(DEFAULT_URL)).rejects.toThrow(FAILURE_STREAM_UNSUPPORTED);
+
+      simulateBrowser();
+      await expect(axiosClient.getStream(DEFAULT_URL)).rejects.toThrow(FAILURE_STREAM_UNSUPPORTED);
+
+      expect(requestConfig).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
- `getBlob()` resolved with a plain **string** in Node: axios honours `responseType: "blob"` only on its XHR adapter, while the http adapter decodes the response as text
- `getStream()` resolved with a **Node.js stream** where `ODataHttpClient` declares a `ReadableStream` - the API doc already said this case should throw
- both satisfied the compiler and blew up at the first `.text()` / `.getReader()`, far from the cause; they now fail at the call, naming the reason and pointing at the FetchClient
- the guard asks the environment (`XMLHttpRequest` present?), not the configured adapter, because that is what axios itself picks the adapter by
- **sending** binary data keeps working on either adapter: only a response that would have to be a `Blob` is refused, so an upload answering 204 is unaffected - a write that does answer with content is refused, since that body can only be a string
- tests state which environment they are in (`vi.stubGlobal("XMLHttpRequest", …)` for the browser case), so both paths stay covered; verified against a real Node HTTP server, where `getBlob` previously returned `String`
- README lists what this client supports and what it does not

BREAKING CHANGE: `getStream()` always throws, `getBlob()` throws outside a browser environment.