### PR TITLE
fix(http-client-base): repeat a request at most once after token expiration

### DIFF
--- a/packages/http-client-base/src/BaseHttpClient.ts
+++ b/packages/http-client-base/src/BaseHttpClient.ts
@@ -140,6 +140,7 @@ export abstract class BaseHttpClient<RequestConfigType> {
    * @param data
    * @param requestConfig
    * @param internalConfig
+   * @param isRetry whether this is already the repetition of a request whose CSRF token had expired
    * @private
    */
   private async sendRequest<ResponseModel>(
@@ -148,6 +149,7 @@ export abstract class BaseHttpClient<RequestConfigType> {
     data: any,
     requestConfig?: RequestConfigType,
     internalConfig: BaseRequestConfig = {},
+    isRetry: boolean = false,
   ): Promise<HttpResponseModel<ResponseModel>> {
     // noinspection SuspiciousTypeOfGuard
     if (typeof url !== "string") {
@@ -176,8 +178,10 @@ export abstract class BaseHttpClient<RequestConfigType> {
     } catch (e) {
       const clientError = e as ODataClientError;
 
-      // automatic CSRF token handling
+      // automatic CSRF token handling: only ever repeat a request once, since a server which keeps
+      // demanding a new token would otherwise make us recurse endlessly
       if (
+        !isRetry &&
         !!this.baseOptions.useCsrfProtection &&
         clientError.status === 403 &&
         !!clientError.headers &&
@@ -187,7 +191,7 @@ export abstract class BaseHttpClient<RequestConfigType> {
         // the internal config must be handed over as well, otherwise the repeated request would lose
         // its headers (content type!) and its data type
         this.csrfToken = undefined;
-        return this.sendRequest<ResponseModel>(method, url, data, requestConfig, internalConfig);
+        return this.sendRequest<ResponseModel>(method, url, data, requestConfig, internalConfig, true);
       }
 
       throw e;

--- a/packages/http-client-base/test/CsrfTokenHandling.test.ts
+++ b/packages/http-client-base/test/CsrfTokenHandling.test.ts
@@ -85,6 +85,19 @@ describe("CSRF Token Handling Tests", () => {
     });
   });
 
+  /**
+   * A server which demands a new token again and again must not send us into an endless loop:
+   * the request is repeated exactly once, then its failure is passed on to the caller.
+   */
+  test("token expiration only leads to one retry", async () => {
+    mockClient.simulateTokenAlwaysExpired = true;
+
+    await expect(mockClient.post("test", {})).rejects.toThrow("Token expired!");
+
+    // token fetch plus the actual request, and that whole game exactly one more time
+    expect(mockClient.requestCount).toBe(4);
+  });
+
   test("set token key", async () => {
     expect(mockClient.getCsrfTokenKey()).toBe("x-csrf-token");
     mockClient.setCsrfTokenKey("");

--- a/packages/http-client-base/test/MockHttpClient.ts
+++ b/packages/http-client-base/test/MockHttpClient.ts
@@ -8,6 +8,8 @@ import {
 } from "@odata2ts/http-client-api";
 import { BaseHttpClient, BaseRequestConfig } from "../src";
 
+const MAX_FAILING_REQUESTS = 10;
+
 export class MockClientError extends Error implements ODataClientError {
   constructor(
     message: string,
@@ -35,8 +37,16 @@ export class MockHttpClient extends BaseHttpClient<MockRequestConfig> implements
   public lastConfig?: MockRequestConfig;
   public lastInternalConfig?: BaseRequestConfig;
 
+  public requestCount: number = 0;
+
   public simulateClientFailure: boolean = false;
   public simulateTokenExpired: boolean = false;
+  /**
+   * Simulates a server which rejects the token no matter how often a new one is fetched.
+   * After MAX_FAILING_REQUESTS it answers with a different error, so that a client which does not
+   * limit its retries fails fast instead of looping forever.
+   */
+  public simulateTokenAlwaysExpired: boolean = false;
 
   constructor(baseOptions?: ODataHttpClientOptions) {
     super(baseOptions);
@@ -71,11 +81,13 @@ export class MockHttpClient extends BaseHttpClient<MockRequestConfig> implements
     this.lastData = data;
     this.lastConfig = config;
     this.lastInternalConfig = internalConfig;
+    this.requestCount++;
 
     const responseHeaders: Record<string, string> = {};
 
     // CSRF token request => custom response
-    if (mergedConfig?.headers && mergedConfig.headers[this.getCsrfTokenKey()] === "Fetch") {
+    const isTokenFetch = mergedConfig?.headers && mergedConfig.headers[this.getCsrfTokenKey()] === "Fetch";
+    if (isTokenFetch) {
       this.generatedCsrfToken = crypto.randomBytes(4).toString("hex");
       responseHeaders[this.getCsrfTokenKey()] = this.generatedCsrfToken;
     }
@@ -83,9 +95,11 @@ export class MockHttpClient extends BaseHttpClient<MockRequestConfig> implements
     if (this.simulateClientFailure) {
       this.simulateClientFailure = false;
       return Promise.reject(new MockClientError("Oh no!", 400, {}, new Error("oh damn!")));
-    } else if (this.simulateTokenExpired) {
+    } else if (this.simulateTokenExpired || (this.simulateTokenAlwaysExpired && !isTokenFetch)) {
       this.simulateTokenExpired = false;
-      return Promise.reject(new MockClientError("Token expired!", 403, { [this.getCsrfTokenKey()]: "Required" }));
+      return this.requestCount > MAX_FAILING_REQUESTS
+        ? Promise.reject(new MockClientError("Too many requests!", 429, {}))
+        : Promise.reject(new MockClientError("Token expired!", 403, { [this.getCsrfTokenKey()]: "Required" }));
     }
 
     return Promise.resolve({


### PR DESCRIPTION
- limit the automatic CSRF retry in `sendRequest` to a single repetition: a server which answers 403 with `x-csrf-token: Required` again and again made the client fetch a new token and repeat the request endlessly, so the failure never reached the caller (and the endless recursion of promises starves the event loop, i.e. the application hangs rather than fails)
- after the one retry the original error is passed on, exactly as with any other failure
- the mock client can now simulate a server which never accepts the token; it gives up after a couple of requests, so that a client without retry limit fails fast in the test instead of looping forever

Follow-up to #38, which brought the retry itself into shape.