### PR TITLE
fix(http-client-base): honor a custom token key when a token expires

### DIFF
--- a/packages/http-client-base/src/BaseHttpClient.ts
+++ b/packages/http-client-base/src/BaseHttpClient.ts
@@ -185,7 +185,7 @@ export abstract class BaseHttpClient<RequestConfigType> {
         !!this.baseOptions.useCsrfProtection &&
         clientError.status === 403 &&
         !!clientError.headers &&
-        clientError.headers["x-csrf-token"] === "Required"
+        clientError.headers[this.csrfTokenKey] === "Required"
       ) {
         // token has expired: reset csrf token & perform the original request again;
         // the internal config must be handed over as well, otherwise the repeated request would lose

--- a/packages/http-client-base/test/CsrfTokenHandling.test.ts
+++ b/packages/http-client-base/test/CsrfTokenHandling.test.ts
@@ -86,6 +86,25 @@ describe("CSRF Token Handling Tests", () => {
   });
 
   /**
+   * The server signals the expired token by the very header it expects the token in, hence the retry
+   * must respect a custom token key instead of looking for the default one.
+   */
+  test("token expiration with custom token key", async () => {
+    const tokenKey = "my-own-token";
+    mockClient.setCsrfTokenKey(tokenKey);
+
+    // the first request caches the token, the second one runs into its expiration
+    await mockClient.post("test", {});
+    const token = mockClient.generatedCsrfToken;
+    mockClient.simulateTokenExpired = true;
+    await mockClient.post("test", {});
+
+    expect(mockClient.generatedCsrfToken).toBeTruthy();
+    expect(mockClient.generatedCsrfToken).not.toBe(token);
+    expect(mockClient.lastInternalConfig?.headers?.[tokenKey]).toBe(mockClient.generatedCsrfToken);
+  });
+
+  /**
    * A server which demands a new token again and again must not send us into an endless loop:
    * the request is repeated exactly once, then its failure is passed on to the caller.
    */


### PR DESCRIPTION
- check the configured `csrfTokenKey` instead of the hardcoded `x-csrf-token` when deciding whether a 403 signals an expired token: the server announces this by the very header it expects the token in, so whoever set another key via `setCsrfTokenKey` never got the automatic retry
- test it with a custom token key; without the fix the 403 lands at the caller instead of being retried

Stacked on top of #41, since it touches the same condition - please merge that one first, then this PR retargets to `main` on its own.