### PR TITLE
feat: upload binary data as a stream

### DIFF
--- a/packages/axios/README.md
+++ b/packages/axios/README.md
@@ -13,8 +13,9 @@ It supports:
 
 It does **not** support:
 
-- **streaming** (`getStream`): axios' XHR adapter cannot stream at all, and its http adapter yields a
-  Node.js stream rather than a `ReadableStream`. The call is refused with an error.
+- **streaming** in either direction (`getStream`, `createStream` / `updateStream`): axios' XHR adapter
+  cannot stream at all, and its http adapter neither accepts a `ReadableStream` as request body nor
+  yields one as response. The call is refused with an error.
 - **binary responses outside the browser** (`getBlob`, and a write answering with the stored content):
   without `XMLHttpRequest` axios falls back to its http adapter, which decodes the response as text, so
   a `Blob` can never be delivered. Refused with an error instead of handing back a string that only

--- a/packages/axios/src/AxiosClient.ts
+++ b/packages/axios/src/AxiosClient.ts
@@ -24,7 +24,8 @@ const FAILURE_AXIOS = "Fatal Axios failure: ";
 
 export const FAILURE_STREAM_UNSUPPORTED =
   "Streaming is not supported by the AxiosClient! Its XHR adapter cannot stream at all, and its http " +
-  "adapter yields a Node.js stream instead of a ReadableStream. Use the FetchClient for streams.";
+  "adapter neither accepts a ReadableStream as request body nor yields one as response. " +
+  "Use the FetchClient for streams.";
 export const FAILURE_BLOB_UNSUPPORTED =
   "Binary responses are not supported by the AxiosClient outside the browser! Without XMLHttpRequest " +
   "axios falls back to its http adapter, which decodes the response as text - so a Blob can never be " +
@@ -92,6 +93,7 @@ export class AxiosClient extends BaseHttpClient<AxiosRequestConfig> implements O
      * declares a `ReadableStream`, and `blob` a plain string where it declares a `Blob`. Both satisfy the
      * compiler and fail at the first `.text()` or `.getReader()` - far away from the cause.
      */
+    // covers both directions: reading a stream as well as sending one as request body
     if (internalConfig.dataType === ODataHttpDataTypes.STREAM) {
       throw new AxiosClientError(FAILURE_STREAM_UNSUPPORTED);
     }

--- a/packages/axios/test/AxiosODataClient.test.ts
+++ b/packages/axios/test/AxiosODataClient.test.ts
@@ -253,6 +253,23 @@ describe("Axios HTTP Client Tests", function () {
       );
     });
 
+    test("sending a stream is refused as well", async () => {
+      // Unlike a blob, a stream cannot even be sent: the http adapter does not accept a ReadableStream
+      // as request body, and the XHR adapter cannot stream in the first place.
+      const data = new Blob(["a"]).stream();
+
+      await expect(axiosClient.createStream(DEFAULT_URL, data, "image/jpg")).rejects.toThrow(
+        FAILURE_STREAM_UNSUPPORTED,
+      );
+
+      simulateBrowser();
+      await expect(axiosClient.updateStream(DEFAULT_URL, data, "image/jpg")).rejects.toThrow(
+        FAILURE_STREAM_UNSUPPORTED,
+      );
+
+      expect(requestConfig).toBeUndefined();
+    });
+
     test("streaming is refused in either environment", async () => {
       // Not an environment question at all: the XHR adapter cannot stream, and the http adapter returns a
       // Node.js stream where the API declares a ReadableStream.

--- a/packages/fetch/README.md
+++ b/packages/fetch/README.md
@@ -10,6 +10,8 @@ It supports:
 
 - request configuration
 - automatic CSRF token handling
+- binary data in both directions: as `Blob` (`getBlob` / `createBlob` / `updateBlob`) and as stream
+  (`getStream` / `createStream` / `updateStream`), the latter being the only client able to do so
 
 Works also for Node.js v18+, but is still marked as **experimental**.
 

--- a/packages/fetch/src/FetchClient.ts
+++ b/packages/fetch/src/FetchClient.ts
@@ -20,7 +20,22 @@ function buildErrorMessage(prefix: string, error: any) {
   return prefix + (msg || DEFAULT_ERROR_MESSAGE);
 }
 
-interface InternalFetchConfig extends FetchRequestConfig, Pick<RequestInit, "method" | "body"> {}
+/**
+ * Whether the body is a stream, in which case fetch needs to be told about it explicitly.
+ *
+ * Guarded by a typeof check, since a runtime without ReadableStream cannot have produced one either.
+ */
+function isReadableStream(body: unknown): body is ReadableStream {
+  return typeof ReadableStream !== "undefined" && body instanceof ReadableStream;
+}
+
+interface InternalFetchConfig extends FetchRequestConfig, Pick<RequestInit, "method" | "body"> {
+  /**
+   * Required by the Fetch standard as soon as the request body is a stream - without it fetch refuses
+   * the request altogether. Declared here since RequestInit does not carry it yet.
+   */
+  duplex?: "half";
+}
 
 export class FetchClient extends BaseHttpClient<FetchRequestConfig> implements ODataHttpClient<FetchRequestConfig> {
   protected readonly config: FetchRequestConfig;
@@ -49,6 +64,10 @@ export class FetchClient extends BaseHttpClient<FetchRequestConfig> implements O
       const serializeAsJson =
         internalConfig.dataType === ODataHttpDataTypes.JSON && !this.isPlainTextBody(internalConfig.headers);
       resultConfig.body = serializeAsJson ? JSON.stringify(data) : data;
+
+      if (isReadableStream(resultConfig.body)) {
+        resultConfig.duplex = "half";
+      }
     }
 
     // apply additional query params to the URL

--- a/packages/fetch/test/FetchODataClient.test.ts
+++ b/packages/fetch/test/FetchODataClient.test.ts
@@ -245,4 +245,42 @@ describe("FetchClient Tests", function () {
     expect(getBaseRequestConfig()).toStrictEqual(DEFAULT_REQUEST_CONFIG);
     expect(getRequestHeaderRecords()).toStrictEqual({});
   });
+
+  /**
+   * A streamed request body requires duplex: fetch refuses the request outright without it.
+   * The blob and JSON tests above pin the counterpart via toStrictEqual: no duplex for other bodies.
+   */
+  test("create stream request", async () => {
+    const mimeType = "text/csv";
+    const stream = new Blob(["hello world"]).stream();
+
+    const response = await fetchClient.createStream(DEFAULT_URL, stream, mimeType);
+
+    expect(response.status).toBe(200);
+    expect(requestUrl).toBe(DEFAULT_URL);
+    expect(getBaseRequestConfig()).toStrictEqual({
+      ...DEFAULT_REQUEST_CONFIG,
+      method: "POST",
+      body: stream,
+      duplex: "half",
+    });
+    expect(getRequestHeaderRecords()).toStrictEqual({ accept: JSON_VALUE, "content-type": mimeType });
+  });
+
+  test("update stream request", async () => {
+    const mimeType = "text/csv";
+    const stream = new Blob(["hello world"]).stream();
+
+    const response = await fetchClient.updateStream(DEFAULT_URL, stream, mimeType);
+
+    expect(response.status).toBe(200);
+    expect(requestUrl).toBe(DEFAULT_URL);
+    expect(getBaseRequestConfig()).toStrictEqual({
+      ...DEFAULT_REQUEST_CONFIG,
+      method: "PUT",
+      body: stream,
+      duplex: "half",
+    });
+    expect(getRequestHeaderRecords()).toStrictEqual({ accept: JSON_VALUE, "content-type": mimeType });
+  });
 });

--- a/packages/http-client-api/src/ODataHttpClient.ts
+++ b/packages/http-client-api/src/ODataHttpClient.ts
@@ -144,4 +144,46 @@ export interface ODataHttpClient<RequestConfig extends ODataRequestConfig = ODat
     requestConfig?: RequestConfig,
     additionalHeaders?: Record<string, string>,
   ): ODataResponse<void | Blob>;
+
+  /**
+   * Creates binary data (Edm.Stream) from a ReadableStream, so that the payload does not have to be
+   * held in memory as a whole.
+   *
+   * Cannot be supported by HTTP clients based on XmlHttpRequest, e.g. axios.
+   * Should throw an error in this case.
+   *
+   * @param url
+   * @param data
+   * @param mimeType
+   * @param requestConfig
+   * @param additionalHeaders
+   */
+  createStream(
+    url: string,
+    data: ReadableStream,
+    mimeType: string,
+    requestConfig?: RequestConfig,
+    additionalHeaders?: Record<string, string>,
+  ): ODataResponse<void | ReadableStream>;
+
+  /**
+   * Updates binary data (Edm.Stream) from a ReadableStream, so that the payload does not have to be
+   * held in memory as a whole.
+   *
+   * Cannot be supported by HTTP clients based on XmlHttpRequest, e.g. axios.
+   * Should throw an error in this case.
+   *
+   * @param url
+   * @param data
+   * @param mimeType
+   * @param requestConfig
+   * @param additionalHeaders
+   */
+  updateStream(
+    url: string,
+    data: ReadableStream,
+    mimeType: string,
+    requestConfig?: RequestConfig,
+    additionalHeaders?: Record<string, string>,
+  ): ODataResponse<void | ReadableStream>;
 }

--- a/packages/http-client-base/src/BaseHttpClient.ts
+++ b/packages/http-client-base/src/BaseHttpClient.ts
@@ -334,4 +334,30 @@ export abstract class BaseHttpClient<RequestConfigType> {
       dataType: ODataHttpDataTypes.BLOB,
     });
   }
+
+  public createStream(
+    url: string,
+    data: ReadableStream,
+    mimeType: string,
+    requestConfig?: RequestConfigType,
+    additionalHeaders?: Record<string, string>,
+  ): ODataResponse<void | ReadableStream> {
+    return this.sendRequest(ODataHttpMethods.Post, url, data, requestConfig, {
+      ...getAdditionalHeaders(true, additionalHeaders, mimeType),
+      dataType: ODataHttpDataTypes.STREAM,
+    });
+  }
+
+  public updateStream(
+    url: string,
+    data: ReadableStream,
+    mimeType: string,
+    requestConfig?: RequestConfigType,
+    additionalHeaders?: Record<string, string>,
+  ): ODataResponse<void | ReadableStream> {
+    return this.sendRequest(ODataHttpMethods.Put, url, data, requestConfig, {
+      ...getAdditionalHeaders(true, additionalHeaders, mimeType),
+      dataType: ODataHttpDataTypes.STREAM,
+    });
+  }
 }

--- a/packages/http-client-base/test/BaseHttpClient.test.ts
+++ b/packages/http-client-base/test/BaseHttpClient.test.ts
@@ -313,6 +313,66 @@ describe("BaseHttpClient Tests", () => {
     });
   });
 
+  test("create stream request", async () => {
+    const data = new Blob(["a", "b"]).stream();
+    const mimeType = "image/png";
+    await mockClient.createStream(DEFAULT_URL, data, mimeType);
+
+    expect(mockClient.lastMethod).toBe("POST");
+    expect(mockClient.lastUrl).toBe(DEFAULT_URL);
+    expect(mockClient.lastData).toBe(data);
+    expect(mockClient.lastConfig).toBeUndefined();
+    expect(mockClient.lastInternalConfig).toStrictEqual({
+      dataType: "stream",
+      headers: DEFAULT_BLOB_HEADERS,
+    });
+  });
+
+  test("create stream request with config and headers", async () => {
+    const data = new Blob(["a", "b"]).stream();
+    const mimeType = "image/png";
+    await mockClient.createStream(DEFAULT_URL, data, mimeType, DEFAULT_CONFIG, ADDITIONAL_HEADERS);
+
+    expect(mockClient.lastMethod).toBe("POST");
+    expect(mockClient.lastUrl).toBe(DEFAULT_URL);
+    expect(mockClient.lastData).toBe(data);
+    expect(mockClient.lastConfig).toStrictEqual(DEFAULT_CONFIG);
+    expect(mockClient.lastInternalConfig).toStrictEqual({
+      dataType: "stream",
+      headers: { ...ADDITIONAL_HEADERS, ...DEFAULT_BLOB_HEADERS },
+    });
+  });
+
+  test("update stream request", async () => {
+    const data = new Blob(["a", "b"]).stream();
+    const mimeType = "image/png";
+    await mockClient.updateStream(DEFAULT_URL, data, mimeType);
+
+    expect(mockClient.lastMethod).toBe("PUT");
+    expect(mockClient.lastUrl).toBe(DEFAULT_URL);
+    expect(mockClient.lastData).toBe(data);
+    expect(mockClient.lastConfig).toBeUndefined();
+    expect(mockClient.lastInternalConfig).toStrictEqual({
+      dataType: "stream",
+      headers: DEFAULT_BLOB_HEADERS,
+    });
+  });
+
+  test("update stream request with config and headers", async () => {
+    const data = new Blob(["a", "b"]).stream();
+    const mimeType = "image/png";
+    await mockClient.updateStream(DEFAULT_URL, data, mimeType, DEFAULT_CONFIG, ADDITIONAL_HEADERS);
+
+    expect(mockClient.lastMethod).toBe("PUT");
+    expect(mockClient.lastUrl).toBe(DEFAULT_URL);
+    expect(mockClient.lastData).toBe(data);
+    expect(mockClient.lastConfig).toStrictEqual(DEFAULT_CONFIG);
+    expect(mockClient.lastInternalConfig).toStrictEqual({
+      dataType: "stream",
+      headers: { ...ADDITIONAL_HEADERS, ...DEFAULT_BLOB_HEADERS },
+    });
+  });
+
   test("retrieveErrorMessage", async () => {
     const message = "my bad!";
     const errorMessageV4 = { error: { message } };

--- a/packages/jquery/README.md
+++ b/packages/jquery/README.md
@@ -10,6 +10,11 @@ The existing JQuery instance must be provided when initializing the client.
 
 The whole client is meant to support usage of `odata2ts` in UI5 apps, which use Jquery for HTTP communication.
 
+It does **not** support **streaming** in either direction (`getStream`, `createStream` / `updateStream`):
+XmlHttpRequest, which jQuery's ajax method builds upon, has no streaming API at all. Those calls are
+refused with an error - use the [Fetch Client](https://www.npmjs.com/package/@odata2ts/http-client-fetch)
+for streams. Binary data as `Blob` works (`getBlob` / `createBlob` / `updateBlob`).
+
 ## Installation
 
 Install package `@odata2ts/http-client-jquery` as runtime dependency:

--- a/packages/jquery/test/JQueryClient.test.ts
+++ b/packages/jquery/test/JQueryClient.test.ts
@@ -244,4 +244,19 @@ describe("JQueryClient Tests", function () {
       "Streaming is not supported by the JqueryClient!",
     );
   });
+
+  test("stream upload not supported either", async () => {
+    const mimeType = "text/csv";
+    const stream = new Blob(["hello world"]).stream();
+
+    await expect(() => jqClient.createStream(DEFAULT_URL, stream, mimeType)).rejects.toThrow(
+      "Streaming is not supported by the JqueryClient!",
+    );
+    await expect(() => jqClient.updateStream(DEFAULT_URL, stream, mimeType)).rejects.toThrow(
+      "Streaming is not supported by the JqueryClient!",
+    );
+
+    // nothing went over the wire
+    expect(jqMock.getRequestConfig()).toBeUndefined();
+  });
 });


### PR DESCRIPTION
- add `createStream` / `updateStream` to the client contract, complementing `createBlob` / `updateBlob`: a `ReadableStream` as request body means the payload no longer has to be held in memory as a whole
- implement both in `BaseHttpClient`, mirroring the blob counterparts down to the mime type handling, with `dataType: stream`
- `FetchClient` declares `duplex: "half"` as soon as the body is a stream - without it fetch refuses the request outright (`RequestInit: duplex option is required when sending a body`). `RequestInit` does not carry the option yet, hence it is declared on the internal config type
- `AxiosClient` and `JQueryClient` refuse the call, exactly as they already do for reading a stream: XmlHttpRequest has no streaming API, and axios' http adapter accepts neither a `ReadableStream` as request body nor yields one as response. Both refusals were already in place for `dataType: stream`, so they cover the new methods without further ado; the axios message and the READMEs now name both directions
- tests: request config in the base client, body plus `duplex` in the fetch client, refusal in axios and jquery. The existing blob and JSON tests pin the counterpart via `toStrictEqual`, i.e. no `duplex` for other bodies

Verified beyond the mocks: against a real `http.createServer`, `createStream` delivers the payload intact with the given content type and gets its 204 - and the same request without `duplex` fails with the error quoted above.

Adding methods to `ODataHttpClient` follows the precedent of #28, which introduced `createBlob` as a plain feat: every client in this repo inherits them from `BaseHttpClient`.