### PR TITLE
fix!: report a refused or absent stream honestly

### DIFF
--- a/packages/fetch/src/FetchClient.ts
+++ b/packages/fetch/src/FetchClient.ts
@@ -13,7 +13,19 @@ export const DEFAULT_ERROR_MESSAGE = "No error message!";
 const FETCH_FAILURE_MESSAGE = "OData request failed entirely: ";
 const JSON_RETRIEVAL_FAILURE_MESSAGE = "Retrieving JSON body from OData response failed: ";
 const BLOB_RETRIEVAL_FAILURE_MESSAGE = "Retrieving blob from OData response failed: ";
+const STREAM_RETRIEVAL_FAILURE_MESSAGE = "Retrieving stream from OData response failed: ";
 const RESPONSE_FAILURE_MESSAGE = "OData server responded with error: ";
+
+function getRetrievalFailureMessage(dataType: ODataHttpDataTypes | undefined) {
+  switch (dataType) {
+    case ODataHttpDataTypes.BLOB:
+      return BLOB_RETRIEVAL_FAILURE_MESSAGE;
+    case ODataHttpDataTypes.STREAM:
+      return STREAM_RETRIEVAL_FAILURE_MESSAGE;
+    default:
+      return JSON_RETRIEVAL_FAILURE_MESSAGE;
+  }
+}
 
 function buildErrorMessage(prefix: string, error: any) {
   const msg = typeof error === "string" ? error : (error as Error)?.message;
@@ -115,7 +127,7 @@ export class FetchClient extends BaseHttpClient<FetchRequestConfig> implements O
     try {
       responseData = noBodyEvaluation ? undefined : await this.getResponseBody(response, internalConfig);
     } catch (error) {
-      const msg = internalConfig.dataType === "blob" ? BLOB_RETRIEVAL_FAILURE_MESSAGE : JSON_RETRIEVAL_FAILURE_MESSAGE;
+      const msg = getRetrievalFailureMessage(internalConfig.dataType);
       throw new FetchClientError(
         buildErrorMessage(msg, error),
         response.status,
@@ -142,7 +154,9 @@ export class FetchClient extends BaseHttpClient<FetchRequestConfig> implements O
       case "blob":
         return response.blob();
       case "stream":
-        return response.body;
+        // a response without any body at all yields null here, which the declared ReadableStream does
+        // not include; undefined is what a 204 already hands back for every other data type
+        return response.body ?? undefined;
     }
 
     return undefined;

--- a/packages/fetch/test/FetchODataClient.test.ts
+++ b/packages/fetch/test/FetchODataClient.test.ts
@@ -14,6 +14,7 @@ describe("FetchClient Tests", function () {
   let requestUrl: string | undefined;
   let requestConfig: RequestInit | undefined;
   let simulateNoContent: boolean = false;
+  let simulateEmptyBody: boolean = false;
 
   // Mocking fetch
   // @ts-ignore: more simplistic parameters and returning different stuff
@@ -30,7 +31,8 @@ describe("FetchClient Tests", function () {
       statusText: "OK",
       headers: new Headers(),
       ok: true,
-      body: DEFAULT_STREAM,
+      // fetch yields null whenever the response carries no body at all
+      body: simulateEmptyBody ? null : DEFAULT_STREAM,
       json: () => Promise.resolve(jsonResult),
       blob: () => Promise.resolve(DEFAULT_BLOB),
     });
@@ -60,6 +62,7 @@ describe("FetchClient Tests", function () {
     requestConfig = undefined;
     fetchClient = new FetchClient();
     simulateNoContent = false;
+    simulateEmptyBody = false;
   });
 
   test("get request", async () => {
@@ -244,6 +247,20 @@ describe("FetchClient Tests", function () {
     expect(response.data).toBe(DEFAULT_STREAM);
     expect(getBaseRequestConfig()).toStrictEqual(DEFAULT_REQUEST_CONFIG);
     expect(getRequestHeaderRecords()).toStrictEqual({});
+  });
+
+  /**
+   * A response without a body leaves fetch with null, which the declared ReadableStream does not
+   * include - handing it on would only be found out at the first getReader().
+   */
+  test("get stream request without a body", async () => {
+    simulateEmptyBody = true;
+
+    const response = await fetchClient.getStream(DEFAULT_URL);
+
+    expect(response.status).toBe(200);
+    expect(response.data).toBeUndefined();
+    expect(response.data).not.toBeNull();
   });
 
   /**

--- a/packages/jquery/src/JQueryClient.ts
+++ b/packages/jquery/src/JQueryClient.ts
@@ -13,6 +13,10 @@ import { JQueryRequestConfig, mergeConfigs } from "./JQueryRequestConfig";
 import jqXHR = JQuery.jqXHR;
 
 export const DEFAULT_ERROR_MESSAGE = "No error message!";
+export const FAILURE_STREAM_UNSUPPORTED =
+  "Streaming is not supported by the JqueryClient! XmlHttpRequest, which jQuery's ajax method builds " +
+  "upon, has no streaming API at all - neither for reading a response nor for sending a request body. " +
+  "Use the FetchClient for streams.";
 
 interface InternalRequestConfig
   extends
@@ -82,7 +86,8 @@ export class JQueryClient extends BaseHttpClient<JQueryRequestConfig> implements
       resultConfig.processData = false;
       resultConfig.contentType = false;
     } else if (internalConfig.dataType === "stream") {
-      throw new Error("Streaming is not supported by the JqueryClient!");
+      // a refusal is a failure of this client like any other, hence it carries the same error type
+      throw new JQueryClientError(FAILURE_STREAM_UNSUPPORTED);
     }
 
     // the actual request

--- a/packages/jquery/src/JQueryClientError.ts
+++ b/packages/jquery/src/JQueryClientError.ts
@@ -5,10 +5,10 @@ import { ODataClientError } from "@odata2ts/http-client-api";
 export class JQueryClientError extends Error implements ODataClientError {
   constructor(
     msg: string,
-    public readonly status: number | undefined,
-    public readonly headers: Record<string, string> | undefined,
-    public readonly cause: Error | undefined,
-    public readonly jqXHR: JQuery.jqXHR,
+    public readonly status?: number,
+    public readonly headers?: Record<string, string>,
+    public readonly cause?: Error,
+    public readonly jqXHR?: JQuery.jqXHR,
   ) {
     // @ts-ignore: fetch requires lib "dom" or "webworker", but then the "cause" property becomes unknown to TS
     super(msg, { cause });

--- a/packages/jquery/test/JQueryClient.test.ts
+++ b/packages/jquery/test/JQueryClient.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, test } from "vitest";
-import { JQueryClient, JQueryRequestConfig } from "../src";
+import { FAILURE_STREAM_UNSUPPORTED, JQueryClient, JQueryClientError, JQueryRequestConfig } from "../src";
 import { JqMock } from "./JQueryMock";
 
 const DEFAULT_URL = "TEST/hi";
@@ -240,9 +240,9 @@ describe("JQueryClient Tests", function () {
   });
 
   test("stream request not supported", async () => {
-    await expect(() => jqClient.getStream(DEFAULT_URL)).rejects.toThrow(
-      "Streaming is not supported by the JqueryClient!",
-    );
+    await expect(() => jqClient.getStream(DEFAULT_URL)).rejects.toThrow(FAILURE_STREAM_UNSUPPORTED);
+    // a refusal is a failure of this client like any other, hence the same error type
+    await expect(() => jqClient.getStream(DEFAULT_URL)).rejects.toBeInstanceOf(JQueryClientError);
   });
 
   test("stream upload not supported either", async () => {
@@ -250,11 +250,9 @@ describe("JQueryClient Tests", function () {
     const stream = new Blob(["hello world"]).stream();
 
     await expect(() => jqClient.createStream(DEFAULT_URL, stream, mimeType)).rejects.toThrow(
-      "Streaming is not supported by the JqueryClient!",
+      FAILURE_STREAM_UNSUPPORTED,
     );
-    await expect(() => jqClient.updateStream(DEFAULT_URL, stream, mimeType)).rejects.toThrow(
-      "Streaming is not supported by the JqueryClient!",
-    );
+    await expect(() => jqClient.updateStream(DEFAULT_URL, stream, mimeType)).rejects.toBeInstanceOf(JQueryClientError);
 
     // nothing went over the wire
     expect(jqMock.getRequestConfig()).toBeUndefined();


### PR DESCRIPTION
Follow-up to #44, cleaning up the three inconsistencies noted there.

**JQueryClient**
- refusing to stream threw a plain `Error`, so the one failure this client raises by itself was the only one not carrying `JQueryClientError` - a caller catching the shared `ODataClientError` contract got nothing from it. It now throws the same error type as every other failure, mirroring how the AxiosClient refuses since #40
- the message is exported as `FAILURE_STREAM_UNSUPPORTED` and says why (XmlHttpRequest has no streaming API, in neither direction) and where to go instead
- to make that possible, the trailing constructor parameters of `JQueryClientError` became optional - `AxiosClientError` and `FetchClientError` have had them optional all along

**FetchClient**
- `response.body` is `null` whenever the response carries no body at all, and that null was handed on although the declared `ReadableStream` does not include it - found out at the first `getReader()`, far away from the cause. It now yields `undefined`, which is what a 204 already produces for every other data type
- a failed stream retrieval was labelled "Retrieving JSON body from OData response failed"; the message is picked per data type now

Tests: the jquery refusals assert the error type (a message assertion alone passed before and after), and the fetch client is pinned on `undefined` rather than `null`. All three fail on the old code.

The corrected failure label is not separately tested: `response.body` cannot throw, so for a stream that catch block is unreachable today - the fix keeps the code honest for whoever reads it next rather than fixing an observable bug.

BREAKING CHANGE: reading `error.jqXHR` now yields `JQuery.jqXHR | undefined` and needs a check under strict TypeScript.