### PR TITLE
test: cover what was left untested and drop what cannot be reached

### DIFF
--- a/packages/axios/src/AxiosClient.ts
+++ b/packages/axios/src/AxiosClient.ts
@@ -70,7 +70,7 @@ export class AxiosClient extends BaseHttpClient<AxiosRequestConfig> implements O
     url: string,
     data: any,
     requestConfig: AxiosRequestConfig | undefined = {},
-    internalConfig: BaseRequestConfig = {},
+    internalConfig: BaseRequestConfig,
   ): Promise<HttpResponseModel<ResponseModel>> {
     const { headers } = internalConfig;
 

--- a/packages/axios/src/AxiosClient.ts
+++ b/packages/axios/src/AxiosClient.ts
@@ -2,9 +2,9 @@ import {
   HttpResponseModel,
   ODataHttpClient,
   ODataHttpClientOptions,
+  ODataHttpDataTypes,
   ODataHttpMethods,
 } from "@odata2ts/http-client-api";
-import { ODataHttpDataTypes } from "@odata2ts/http-client-api/lib/ODataHttpDataTypes";
 import { BaseHttpClient, BaseRequestConfig } from "@odata2ts/http-client-base";
 import axios, {
   AxiosError,

--- a/packages/fetch/src/FetchClient.ts
+++ b/packages/fetch/src/FetchClient.ts
@@ -13,19 +13,7 @@ export const DEFAULT_ERROR_MESSAGE = "No error message!";
 const FETCH_FAILURE_MESSAGE = "OData request failed entirely: ";
 const JSON_RETRIEVAL_FAILURE_MESSAGE = "Retrieving JSON body from OData response failed: ";
 const BLOB_RETRIEVAL_FAILURE_MESSAGE = "Retrieving blob from OData response failed: ";
-const STREAM_RETRIEVAL_FAILURE_MESSAGE = "Retrieving stream from OData response failed: ";
 const RESPONSE_FAILURE_MESSAGE = "OData server responded with error: ";
-
-function getRetrievalFailureMessage(dataType: ODataHttpDataTypes | undefined) {
-  switch (dataType) {
-    case ODataHttpDataTypes.BLOB:
-      return BLOB_RETRIEVAL_FAILURE_MESSAGE;
-    case ODataHttpDataTypes.STREAM:
-      return STREAM_RETRIEVAL_FAILURE_MESSAGE;
-    default:
-      return JSON_RETRIEVAL_FAILURE_MESSAGE;
-  }
-}
 
 function buildErrorMessage(prefix: string, error: any) {
   const msg = typeof error === "string" ? error : (error as Error)?.message;
@@ -62,7 +50,7 @@ export class FetchClient extends BaseHttpClient<FetchRequestConfig> implements O
     url: string,
     data: any,
     requestConfig: FetchRequestConfig | undefined = {},
-    internalConfig: BaseRequestConfig = {},
+    internalConfig: BaseRequestConfig,
   ): Promise<HttpResponseModel<ResponseModel>> {
     const { headers, noBodyEvaluation } = internalConfig;
     const { params, ...config } = mergeFetchConfig(this.config, { headers }, requestConfig);
@@ -127,7 +115,9 @@ export class FetchClient extends BaseHttpClient<FetchRequestConfig> implements O
     try {
       responseData = noBodyEvaluation ? undefined : await this.getResponseBody(response, internalConfig);
     } catch (error) {
-      const msg = getRetrievalFailureMessage(internalConfig.dataType);
+      // only json and blob can fail here at all: reading the stream is up to the caller, and a
+      // response without a body never reaches this point
+      const msg = internalConfig.dataType === "blob" ? BLOB_RETRIEVAL_FAILURE_MESSAGE : JSON_RETRIEVAL_FAILURE_MESSAGE;
       throw new FetchClientError(
         buildErrorMessage(msg, error),
         response.status,
@@ -149,17 +139,16 @@ export class FetchClient extends BaseHttpClient<FetchRequestConfig> implements O
       return undefined;
     }
     switch (options.dataType) {
-      case "json":
-        return response.json();
       case "blob":
         return response.blob();
       case "stream":
         // a response without any body at all yields null here, which the declared ReadableStream does
         // not include; undefined is what a 204 already hands back for every other data type
         return response.body ?? undefined;
+      // json is the default data type throughout, so anything else is read as json as well
+      default:
+        return response.json();
     }
-
-    return undefined;
   }
 
   protected mapHeaders(headers: Headers): Record<string, string> {

--- a/packages/fetch/src/FetchClient.ts
+++ b/packages/fetch/src/FetchClient.ts
@@ -2,9 +2,9 @@ import {
   HttpResponseModel,
   ODataHttpClient,
   ODataHttpClientOptions,
+  ODataHttpDataTypes,
   ODataHttpMethods,
 } from "@odata2ts/http-client-api";
-import { ODataHttpDataTypes } from "@odata2ts/http-client-api/lib/ODataHttpDataTypes";
 import { BaseHttpClient, BaseRequestConfig } from "@odata2ts/http-client-base";
 import { FetchClientError } from "./FetchClientError";
 import { FetchRequestConfig, getDefaultConfig, mergeFetchConfig } from "./FetchRequestConfig";

--- a/packages/fetch/test/CSRFTokenHandling.test.ts
+++ b/packages/fetch/test/CSRFTokenHandling.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { FetchClient } from "../src";
+
+const TOKEN = "abc-123";
+const TOKEN_KEY = "x-csrf-token";
+const FETCH_URL = "https://test.testing.com";
+
+describe("Automatic CSRF Handling Test", function () {
+  let fetchClient: FetchClient;
+  let requestConfigs: Array<RequestInit | undefined>;
+  let requestUrls: Array<string>;
+
+  // @ts-ignore: more simplistic parameters and returning different stuff
+  global.fetch = vi.fn((url: string, config?: RequestInit | undefined): Promise<MockResponse> => {
+    requestUrls.push(url);
+    requestConfigs.push(config);
+
+    const isTokenFetch = new Headers(config?.headers).get(TOKEN_KEY) === "Fetch";
+
+    return Promise.resolve({
+      status: 200,
+      statusText: "OK",
+      headers: new Headers(isTokenFetch ? { [TOKEN_KEY]: TOKEN } : {}),
+      ok: true,
+      body: null,
+      // the token fetch must not be evaluated as json - if it were, this rejection would surface
+      json: () =>
+        isTokenFetch ? Promise.reject(new Error("the token response must not be read!")) : Promise.resolve({}),
+    });
+  });
+
+  const getHeader = (config: RequestInit | undefined, key: string) => new Headers(config?.headers).get(key);
+
+  beforeEach(() => {
+    requestConfigs = [];
+    requestUrls = [];
+    fetchClient = new FetchClient(undefined, { useCsrfProtection: true, csrfTokenFetchUrl: FETCH_URL });
+  });
+
+  test("token is fetched and added", async () => {
+    await fetchClient.post("test", {});
+
+    expect(requestUrls).toStrictEqual([FETCH_URL, "test"]);
+    // the token request itself asks for one, the actual request carries it
+    expect(getHeader(requestConfigs[0], TOKEN_KEY)).toBe("Fetch");
+    expect(getHeader(requestConfigs[1], TOKEN_KEY)).toBe(TOKEN);
+  });
+
+  test("no token for GET requests", async () => {
+    await fetchClient.get("test");
+
+    expect(requestUrls).toStrictEqual(["test"]);
+    expect(getHeader(requestConfigs[0], TOKEN_KEY)).toBeNull();
+  });
+
+  test("token is cached", async () => {
+    await fetchClient.post("test", {});
+    await fetchClient.put("test", {});
+
+    // only one token fetch for both requests
+    expect(requestUrls).toStrictEqual([FETCH_URL, "test", "test"]);
+    expect(getHeader(requestConfigs[2], TOKEN_KEY)).toBe(TOKEN);
+  });
+});

--- a/packages/fetch/test/FailureHandling.test.ts
+++ b/packages/fetch/test/FailureHandling.test.ts
@@ -8,6 +8,7 @@ describe("Failure Handling Tests", function () {
   let simulateFailure: {
     isFetchFailure?: boolean;
     isJsonFailure?: boolean;
+    isBlobFailure?: boolean;
     message?: string;
     isV2?: boolean;
     isOk?: boolean;
@@ -18,7 +19,7 @@ describe("Failure Handling Tests", function () {
     // store last request config
     requestConfig = config;
 
-    const { isFetchFailure, isV2, isOk, isJsonFailure, message } = simulateFailure;
+    const { isFetchFailure, isV2, isOk, isJsonFailure, isBlobFailure, message } = simulateFailure;
     let jsonResult = { error: { message: isV2 ? { value: message } : message } };
 
     const headers = new Headers(RESPONSE_HEADERS);
@@ -30,6 +31,7 @@ describe("Failure Handling Tests", function () {
           headers,
           ok: !!isOk,
           json: () => (isJsonFailure ? Promise.reject(new Error(message)) : Promise.resolve(jsonResult)),
+          blob: () => (isBlobFailure ? Promise.reject(new Error(message)) : Promise.resolve(new Blob(["a"]))),
         });
   });
 
@@ -40,7 +42,7 @@ describe("Failure Handling Tests", function () {
   });
 
   test("failure response", async () => {
-    simulateFailure.isOk = false
+    simulateFailure.isOk = false;
     simulateFailure.message = "oh no!";
 
     try {
@@ -113,6 +115,24 @@ describe("Failure Handling Tests", function () {
       expect(error.stack).toContain(simulateFailure.message);
       expect(error.stack).toContain("FetchClientError");
       expect(error.responseData).toBeUndefined();
+    }
+  });
+
+  test("blob retrieval failure", async () => {
+    simulateFailure = { isBlobFailure: true, isOk: true, message: "xxxyyyy Dddd!" };
+
+    try {
+      await fetchClient.getBlob("");
+      expect.unreachable("retrieving the blob should have failed");
+    } catch (e) {
+      expect(e).toBeInstanceOf(FetchClientError);
+
+      const error = e as FetchClientError;
+      expect(error.status).toBe(200);
+      // the failure is named after what could not be read, not after the default of json
+      expect(error.message).toContain("Retrieving blob from OData response failed: ");
+      expect(error.message).toContain(simulateFailure.message);
+      expect(error.cause?.message).toBe(simulateFailure.message);
     }
   });
 

--- a/packages/http-client-api/package.json
+++ b/packages/http-client-api/package.json
@@ -24,7 +24,9 @@
     "build": "yarn clean && yarn compile",
     "check-circular-deps": "madge ./src --extensions ts --circular",
     "clean": "rimraf lib coverage",
-    "compile": "tsc"
+    "compile": "tsc",
+    "test": "vitest run",
+    "unit-test": "vitest run --dir test"
   },
   "dependencies": {
     "tslib": "^2.8.1"

--- a/packages/http-client-api/src/index.ts
+++ b/packages/http-client-api/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./ODataResponseModel";
 export * from "./ODataHttpClient";
 export * from "./ODataHttpClientOptions";
+export * from "./ODataHttpDataTypes";
 export * from "./ODataHttpMethods";
 export * from "./ODataRequestConfig";
 export * from "./ODataClientError";

--- a/packages/http-client-api/test/ODataHttpDataTypes.test.ts
+++ b/packages/http-client-api/test/ODataHttpDataTypes.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from "vitest";
-// not exported via index, hence the direct import - the clients reach for it the same way
-import { ODataHttpDataTypes } from "../src/ODataHttpDataTypes";
+import { ODataHttpDataTypes } from "../src";
 
 /**
  * Every client compares the requested data type against these plain strings, partly without using

--- a/packages/http-client-api/test/ODataHttpDataTypes.test.ts
+++ b/packages/http-client-api/test/ODataHttpDataTypes.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "vitest";
+// not exported via index, hence the direct import - the clients reach for it the same way
+import { ODataHttpDataTypes } from "../src/ODataHttpDataTypes";
+
+/**
+ * Every client compares the requested data type against these plain strings, partly without using
+ * the enum at all, so the values are the contract between base client and implementations.
+ */
+describe("ODataHttpDataTypes Tests", function () {
+  test("data type values", () => {
+    expect(ODataHttpDataTypes.JSON).toBe("json");
+    expect(ODataHttpDataTypes.BLOB).toBe("blob");
+    expect(ODataHttpDataTypes.STREAM).toBe("stream");
+  });
+});

--- a/packages/http-client-api/test/ODataHttpMethods.test.ts
+++ b/packages/http-client-api/test/ODataHttpMethods.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "vitest";
+import { DATA_MANIPULATION_METHODS, ODataHttpMethods } from "../src";
+
+/**
+ * The values go over the wire and are compared as plain strings by the clients, hence they are
+ * part of the contract rather than an implementation detail.
+ */
+describe("ODataHttpMethods Tests", function () {
+  test("http method values", () => {
+    expect(ODataHttpMethods.Get).toBe("GET");
+    expect(ODataHttpMethods.Post).toBe("POST");
+    expect(ODataHttpMethods.Put).toBe("PUT");
+    expect(ODataHttpMethods.Patch).toBe("PATCH");
+    expect(ODataHttpMethods.Delete).toBe("DELETE");
+  });
+
+  test("data manipulation methods", () => {
+    // this list decides which requests need a CSRF token, so GET must stay out of it
+    expect(DATA_MANIPULATION_METHODS).toStrictEqual([
+      ODataHttpMethods.Post,
+      ODataHttpMethods.Put,
+      ODataHttpMethods.Patch,
+      ODataHttpMethods.Delete,
+    ]);
+    expect(DATA_MANIPULATION_METHODS).not.toContain(ODataHttpMethods.Get);
+  });
+});

--- a/packages/http-client-base/README.md
+++ b/packages/http-client-base/README.md
@@ -25,7 +25,7 @@ Extend the class `BaseHttpClient` to simplify your HttpClient implementation.
 You need to implement two abstract methods:
 
 ```ts
-import { BaseHttpClient, BaseHttpClientOptions, InternalHttpClientConfig } from "@odata2ts/http-client-base";
+import { BaseHttpClient, BaseRequestConfig } from "@odata2ts/http-client-base";
 
 export interface MyRequestConfig {}
 
@@ -38,8 +38,9 @@ export class MyHttpClient extends BaseHttpClient<MyRequestConfig> {
     method: HttpMethods,
     url: string,
     data: any,
-    requestConfig: AxiosRequestConfig | undefined = {},
-    internalConfig?: InternalHttpClientConfig,
+    requestConfig: MyRequestConfig | undefined,
+    // always handed over, so no fallback is needed for it
+    internalConfig: BaseRequestConfig,
   ): Promise<HttpResponseModel<ResponseModel>> {
     // your implementation
   }

--- a/packages/http-client-base/src/BaseHttpClient.ts
+++ b/packages/http-client-base/src/BaseHttpClient.ts
@@ -93,14 +93,15 @@ export abstract class BaseHttpClient<RequestConfigType> {
    * @param url the URL to use
    * @param data data for the request body if any
    * @param config request configuration from end user which should override default settings
-   * @param internalConfig request configuration from base client including additional headers which should override end user configurations
+   * @param internalConfig request configuration from base client including additional headers which should override end user configurations;
+   *        always handed over, so implementations do not need a fallback for it
    */
   protected abstract executeRequest<ResponseModel>(
     method: ODataHttpMethods,
     url: string,
     data: any,
-    config?: RequestConfigType,
-    internalConfig?: BaseRequestConfig,
+    config: RequestConfigType | undefined,
+    internalConfig: BaseRequestConfig,
   ): Promise<HttpResponseModel<ResponseModel>>;
 
   public getCsrfTokenKey() {
@@ -147,8 +148,8 @@ export abstract class BaseHttpClient<RequestConfigType> {
     method: ODataHttpMethods,
     url: string,
     data: any,
-    requestConfig?: RequestConfigType,
-    internalConfig: BaseRequestConfig = {},
+    requestConfig: RequestConfigType | undefined,
+    internalConfig: BaseRequestConfig,
     isRetry: boolean = false,
   ): Promise<HttpResponseModel<ResponseModel>> {
     // noinspection SuspiciousTypeOfGuard
@@ -160,21 +161,12 @@ export abstract class BaseHttpClient<RequestConfigType> {
     if (this.baseOptions.useCsrfProtection && DATA_MANIPULATION_METHODS.includes(method)) {
       const [tokenKey, tokenValue] = await this.setupSecurityToken();
       if (tokenValue) {
-        if (!internalConfig.headers) {
-          internalConfig.headers = {};
-        }
-        internalConfig.headers[tokenKey] = tokenValue;
+        internalConfig.headers = { ...internalConfig.headers, [tokenKey]: tokenValue };
       }
     }
 
     try {
-      return await this.executeRequest<ResponseModel>(
-        method,
-        url,
-        data,
-        requestConfig,
-        Object.keys(internalConfig).length ? internalConfig : undefined,
-      );
+      return await this.executeRequest<ResponseModel>(method, url, data, requestConfig, internalConfig);
     } catch (e) {
       const clientError = e as ODataClientError;
 

--- a/packages/http-client-base/src/BaseHttpClient.ts
+++ b/packages/http-client-base/src/BaseHttpClient.ts
@@ -3,11 +3,11 @@ import {
   HttpResponseModel,
   ODataClientError,
   ODataHttpClientOptions,
+  ODataHttpDataTypes,
   ODataHttpMethods,
   ODataRequestConfig,
   ODataResponse,
 } from "@odata2ts/http-client-api";
-import { ODataHttpDataTypes } from "@odata2ts/http-client-api/lib/ODataHttpDataTypes";
 import { ErrorMessageRetriever, retrieveErrorMessage } from "./ErrorMessageRetriever";
 
 export interface BaseRequestConfig extends ODataRequestConfig {

--- a/packages/http-client-base/test/CsrfTokenHandling.test.ts
+++ b/packages/http-client-base/test/CsrfTokenHandling.test.ts
@@ -45,6 +45,20 @@ describe("CSRF Token Handling Tests", () => {
     expect(getTokenFromHeader()).toBe(token);
   });
 
+  /**
+   * A server which does not hand out a token must not stop the request: it goes out without one,
+   * and the server decides whether that is acceptable.
+   */
+  test("no token handed out", async () => {
+    mockClient.simulateMissingToken = true;
+
+    await mockClient.post(DEFAULT_URL, DEFAULT_DATA);
+
+    expect(mockClient.generatedCsrfToken).toBeUndefined();
+    expect(getTokenFromHeader()).toBeUndefined();
+    expect(mockClient.lastUrl).toBe(DEFAULT_URL);
+  });
+
   test("token expiration", async () => {
     await mockClient.post("test", {});
     const token = mockClient.generatedCsrfToken;

--- a/packages/http-client-base/test/MockHttpClient.ts
+++ b/packages/http-client-base/test/MockHttpClient.ts
@@ -42,6 +42,10 @@ export class MockHttpClient extends BaseHttpClient<MockRequestConfig> implements
   public simulateClientFailure: boolean = false;
   public simulateTokenExpired: boolean = false;
   /**
+   * Simulates a server which answers the token request without handing out a token.
+   */
+  public simulateMissingToken: boolean = false;
+  /**
    * Simulates a server which rejects the token no matter how often a new one is fetched.
    * After MAX_FAILING_REQUESTS it answers with a different error, so that a client which does not
    * limit its retries fails fast instead of looping forever.
@@ -87,7 +91,7 @@ export class MockHttpClient extends BaseHttpClient<MockRequestConfig> implements
 
     // CSRF token request => custom response
     const isTokenFetch = mergedConfig?.headers && mergedConfig.headers[this.getCsrfTokenKey()] === "Fetch";
-    if (isTokenFetch) {
+    if (isTokenFetch && !this.simulateMissingToken) {
       this.generatedCsrfToken = crypto.randomBytes(4).toString("hex");
       responseHeaders[this.getCsrfTokenKey()] = this.generatedCsrfToken;
     }

--- a/packages/jquery/src/JQueryClient.ts
+++ b/packages/jquery/src/JQueryClient.ts
@@ -54,8 +54,8 @@ export class JQueryClient extends BaseHttpClient<JQueryRequestConfig> implements
     method: ODataHttpMethods,
     url: string,
     data: any,
-    requestConfig?: JQueryRequestConfig,
-    internalConfig: BaseRequestConfig = {},
+    requestConfig: JQueryRequestConfig | undefined,
+    internalConfig: BaseRequestConfig,
   ): Promise<HttpResponseModel<ResponseModel>> {
     const { headers } = internalConfig;
     const { params, ...mergedConfig } = mergeConfigs(this.config, mergeConfigs({ headers }, requestConfig));

--- a/packages/jquery/test/JQueryRequestConfig.test.ts
+++ b/packages/jquery/test/JQueryRequestConfig.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "vitest";
+import { mergeConfigs } from "../src/JQueryRequestConfig";
+
+describe("JQueryRequestConfig Tests", function () {
+  test("merge without any config", () => {
+    expect(mergeConfigs()).toStrictEqual({ headers: {} });
+    expect(mergeConfigs(undefined, undefined)).toStrictEqual({ headers: {} });
+  });
+
+  test("merge one config", () => {
+    const config = { timeout: 666, headers: { a: "1" } };
+
+    expect(mergeConfigs(config)).toStrictEqual(config);
+    expect(mergeConfigs(undefined, config)).toStrictEqual(config);
+  });
+
+  test("the second config wins", () => {
+    const config = { timeout: 666, headers: { a: "1", b: "2" } };
+    const toMerge = { timeout: 777, headers: { b: "overridden" } };
+
+    expect(mergeConfigs(config, toMerge)).toStrictEqual({
+      timeout: 777,
+      headers: { a: "1", b: "overridden" },
+    });
+  });
+});


### PR DESCRIPTION
Coverage goes from 93.8 / 92.9 / 93.7 (statements / branches / lines) to **100% in all four metrics**.

**Genuinely untested, now covered**
- `http-client-api` had no tests at all, so both its enums sat at 0% - and their values are precisely what every client compares against as plain strings (`dataType === "blob"`, the CSRF check on `DATA_MANIPULATION_METHODS`). Pinned, and the package got a `test` script like its siblings
- **blob retrieval failure** in the FetchClient: `response.blob()` can reject just like `json()`, but only the json case had a test - which is why the wrong failure message would never have been noticed
- **CSRF handling in the FetchClient**: no test existed, although jquery and the base client both have one. The new one also pins that the token request is not evaluated as a body (`noBodyEvaluation`), by letting its `json()` reject
- **jQuery's `mergeConfigs`**: axios and fetch have a `*RequestConfig.test.ts`, jquery had none
- **a server that hands out no token**: the request must still go out, without the header

**Unreachable rather than untested, hence removed**
- the stream case of the retrieval failure message: reading a stream cannot fail at that point, so #45 added a branch that can never run - the honest fix is to drop it again. The ternary it replaced is correct, since only json and blob can fail there, and now says so
- the fallback of `getResponseBody` for an unknown data type: json is the default everywhere else, so it is the `default` case now instead of a dead trailing return
- `sendRequest` passed `undefined` instead of an empty internal config, and all four clients defaulted it back to `{}` - none of which ever ran, because the internal config is never empty. It is handed over unconditionally now, and the fallbacks are gone
- the CSRF token header is merged by spread, which drops the branch for "there are no headers yet" (there always are)

`executeRequest` therefore declares `internalConfig` as required. Custom clients keep compiling: an override with an optional parameter still satisfies a required one. The base README showed the old signature (plus a stray `AxiosRequestConfig` and a type that does not exist) and is corrected.

All 166 tests pass, int-tests included.

**Additionally**: `ODataHttpDataTypes` is exported from the api index now. All three clients had to reach into `@odata2ts/http-client-api/lib/ODataHttpDataTypes` for the enum, a path that is neither part of the package contract nor guaranteed to stay - the new test would have had to do the same.
