### PR TITLE
fix!: surface the server's message when a binary request fails

### DIFF
--- a/packages/axios/src/AxiosClient.ts
+++ b/packages/axios/src/AxiosClient.ts
@@ -5,7 +5,7 @@ import {
   ODataHttpDataTypes,
   ODataHttpMethods,
 } from "@odata2ts/http-client-api";
-import { BaseHttpClient, BaseRequestConfig } from "@odata2ts/http-client-base";
+import { BaseHttpClient, BaseRequestConfig, parseErrorResponseBody } from "@odata2ts/http-client-base";
 import axios, {
   AxiosError,
   AxiosInstance,
@@ -112,7 +112,11 @@ export class AxiosClient extends BaseHttpClient<AxiosRequestConfig> implements O
 
         // regular failure handling
         if (axiosError.response) {
-          const errMsg = this.retrieveErrorMessage(axiosError.response.data);
+          // axios applied the request's responseType to the error response as well, so a failing
+          // `getBlob` leaves a Blob here (XHR adapter) resp. an unparsed string (http adapter) - either
+          // way the OData error document inside it has to be decoded before it can be read
+          const responseData = await parseErrorResponseBody(axiosError.response.data);
+          const errMsg = this.retrieveErrorMessage(responseData);
           const msg = buildErrorMessage(FAILURE_RESPONSE_MESSAGE, errMsg);
           throw new AxiosClientError(
             msg,

--- a/packages/axios/test/FailureHandling.test.ts
+++ b/packages/axios/test/FailureHandling.test.ts
@@ -20,6 +20,11 @@ describe("Failure Handling Tests", function () {
     isEmptyBody?: boolean;
     message?: string;
     isV2?: boolean;
+    /**
+     * How the error document arrives: axios applies the request's `responseType` to it as well, so a
+     * failing binary request leaves a Blob (XHR adapter) resp. an unparsed string (http adapter) here.
+     */
+    bodyAs?: "blob" | "string";
   } = {};
 
   // @ts-ignore
@@ -33,8 +38,14 @@ describe("Failure Handling Tests", function () {
         ...defaultConfig,
         ...config,
       } as AxiosRequestConfig;
-      const { isPlainError, isRequestFailure, isResponseFailure, isEmptyBody, message, isV2 } = simulateFailure;
-      let jsonResult = { error: { message: isV2 ? { value: message } : message } };
+      const { isPlainError, isRequestFailure, isResponseFailure, isEmptyBody, message, isV2, bodyAs } = simulateFailure;
+      const errorDocument = { error: { message: isV2 ? { value: message } : message } };
+      const jsonResult =
+        bodyAs === "blob"
+          ? new Blob([JSON.stringify(errorDocument)])
+          : bodyAs === "string"
+            ? JSON.stringify(errorDocument)
+            : errorDocument;
 
       if (isPlainError) {
         return Promise.reject(new Error(message));
@@ -145,6 +156,35 @@ describe("Failure Handling Tests", function () {
       expect(error.stack).toContain(simulateFailure.message);
       expect(error.stack).toContain("AxiosClientError");
     }
+  });
+
+  /**
+   * The request's `responseType` describes the successful payload, but axios applies it to the error
+   * response as well - so the OData error document of a failing binary request arrives as a Blob or as
+   * an unparsed string, and reading it as it is left every such failure reporting the default message.
+   *
+   * `updateBlob` rather than `getBlob`, since reading binary is refused up front without XMLHttpRequest.
+   */
+  describe("error response to a binary request", () => {
+    const blob = new Blob(["a"], { type: "application/epub+zip" });
+
+    test("an error document arriving as a Blob is decoded", async () => {
+      simulateFailure = { message: "oh no!", bodyAs: "blob" };
+
+      await expect(axiosClient.updateBlob("", blob, "application/epub+zip")).rejects.toThrow(simulateFailure.message);
+    });
+
+    test("an error document arriving as an unparsed string is parsed", async () => {
+      simulateFailure = { isV2: true, message: "oh no!", bodyAs: "string" };
+
+      await expect(axiosClient.updateBlob("", blob, "application/epub+zip")).rejects.toThrow(simulateFailure.message);
+    });
+
+    test("a body which is neither stays the default message", async () => {
+      simulateFailure = { isEmptyBody: true, bodyAs: "blob" };
+
+      await expect(axiosClient.updateBlob("", blob, "application/epub+zip")).rejects.toThrow(DEFAULT_ERROR_MESSAGE);
+    });
   });
 
   test("custom failure message retriever", async () => {

--- a/packages/fetch/src/FetchClient.ts
+++ b/packages/fetch/src/FetchClient.ts
@@ -5,7 +5,7 @@ import {
   ODataHttpDataTypes,
   ODataHttpMethods,
 } from "@odata2ts/http-client-api";
-import { BaseHttpClient, BaseRequestConfig } from "@odata2ts/http-client-base";
+import { BaseHttpClient, BaseRequestConfig, parseErrorResponseBody } from "@odata2ts/http-client-base";
 import { FetchClientError } from "./FetchClientError";
 import { FetchRequestConfig, getDefaultConfig, mergeFetchConfig } from "./FetchRequestConfig";
 
@@ -96,7 +96,7 @@ export class FetchClient extends BaseHttpClient<FetchRequestConfig> implements O
     if (!response.ok) {
       let responseData;
       try {
-        responseData = await this.getResponseBody(response, internalConfig);
+        responseData = await this.getErrorResponseBody(response);
       } catch (e) {
         responseData = undefined;
       }
@@ -149,6 +149,22 @@ export class FetchClient extends BaseHttpClient<FetchRequestConfig> implements O
       default:
         return response.json();
     }
+  }
+
+  /**
+   * The body of a failed response, read independently of what the request asked for.
+   *
+   * `getResponseBody` would apply the request's data type, which describes the successful payload: a
+   * `getBlob` would read the server's error document as binary and a `getStream` would hand the unread
+   * stream on, so the message inside it never reaches the caller. Text is what every error document has
+   * in common, whether it turns out to be JSON or not.
+   */
+  protected async getErrorResponseBody(response: Response) {
+    if (response.status === 204) {
+      return undefined;
+    }
+
+    return parseErrorResponseBody(await response.text());
   }
 
   protected mapHeaders(headers: Headers): Record<string, string> {

--- a/packages/fetch/test/FailureHandling.test.ts
+++ b/packages/fetch/test/FailureHandling.test.ts
@@ -12,6 +12,8 @@ describe("Failure Handling Tests", function () {
     message?: string;
     isV2?: boolean;
     isOk?: boolean;
+    /** The error body as the server sends it, for the cases where it is not an OData error document. */
+    rawBody?: string;
   } = {};
 
   // @ts-ignore: more simplistic parameters and returning different stuff
@@ -19,8 +21,9 @@ describe("Failure Handling Tests", function () {
     // store last request config
     requestConfig = config;
 
-    const { isFetchFailure, isV2, isOk, isJsonFailure, isBlobFailure, message } = simulateFailure;
+    const { isFetchFailure, isV2, isOk, isJsonFailure, isBlobFailure, message, rawBody } = simulateFailure;
     let jsonResult = { error: { message: isV2 ? { value: message } : message } };
+    const bodyText = rawBody ?? JSON.stringify(jsonResult);
 
     const headers = new Headers(RESPONSE_HEADERS);
     return isFetchFailure
@@ -31,6 +34,8 @@ describe("Failure Handling Tests", function () {
           headers,
           ok: !!isOk,
           json: () => (isJsonFailure ? Promise.reject(new Error(message)) : Promise.resolve(jsonResult)),
+          // the error path reads the body as text, whatever the request asked for
+          text: () => (isJsonFailure ? Promise.reject(new Error(message)) : Promise.resolve(bodyText)),
           blob: () => (isBlobFailure ? Promise.reject(new Error(message)) : Promise.resolve(new Blob(["a"]))),
         });
   });
@@ -136,8 +141,8 @@ describe("Failure Handling Tests", function () {
     }
   });
 
-  // when the whole request failed, any failures that occur on calling the json function are non-fatal
-  test("failure request and json retrieval failure", async () => {
+  // when the whole request failed, any failures that occur on reading the response body are non-fatal
+  test("failure request and body retrieval failure", async () => {
     simulateFailure = { isJsonFailure: true, isOk: false, message: "xxxyyyy Dddd!" };
 
     try {
@@ -152,6 +157,73 @@ describe("Failure Handling Tests", function () {
       expect(error.cause).toBeInstanceOf(Error);
       expect(error.cause?.message).toBe(DEFAULT_ERROR_MESSAGE);
     }
+  });
+
+  /**
+   * What the request asked for says nothing about the failure: a server answers a `getBlob` or a
+   * `getStream` with an ordinary OData error document. Reading that document the way the successful
+   * payload would have been read - as a Blob, or by handing the unread stream on - left every failure of
+   * a binary request reporting the client's default message.
+   */
+  describe("error response to a binary request", () => {
+    test("a failing getBlob reports the server's message", async () => {
+      simulateFailure = { message: "oh no!" };
+
+      try {
+        await fetchClient.getBlob("");
+        expect.unreachable("the request should have failed");
+      } catch (e) {
+        const error = e as FetchClientError;
+        expect(error.status).toBe(400);
+        expect(error.message).toContain(simulateFailure.message);
+        expect(error.cause?.message).toBe(simulateFailure.message);
+        // and the document itself is passed on, not the Blob it arrived in
+        expect(error.responseData).toStrictEqual({ error: { message: simulateFailure.message } });
+      }
+    });
+
+    test("a failing getStream reports the server's message", async () => {
+      simulateFailure = { isV2: true, message: "oh no!" };
+
+      await expect(fetchClient.getStream("")).rejects.toThrow(simulateFailure.message);
+    });
+
+    test("a failing updateBlob reports the server's message", async () => {
+      simulateFailure = { message: "oh no!" };
+
+      await expect(fetchClient.updateBlob("", new Blob(["a"]), "application/epub+zip")).rejects.toThrow(
+        simulateFailure.message,
+      );
+    });
+
+    test("a body which is not JSON is passed on as text", async () => {
+      // An OData V2 server answers in XML unless asked otherwise, and a binary request cannot ask: its
+      // response is bytes, not JSON. Parsing that is beyond the default retriever, so the message stays
+      // the fallback - but the document reaches the caller instead of being lost in a Blob.
+      simulateFailure = { rawBody: "<error><message>Requested entity could not be found.</message></error>" };
+
+      try {
+        await fetchClient.getBlob("");
+        expect.unreachable("the request should have failed");
+      } catch (e) {
+        const error = e as FetchClientError;
+        expect(error.message).toContain(DEFAULT_ERROR_MESSAGE);
+        expect(error.responseData).toBe(simulateFailure.rawBody);
+      }
+    });
+
+    test("an empty body yields no data at all", async () => {
+      simulateFailure = { rawBody: "" };
+
+      try {
+        await fetchClient.getBlob("");
+        expect.unreachable("the request should have failed");
+      } catch (e) {
+        const error = e as FetchClientError;
+        expect(error.message).toContain(DEFAULT_ERROR_MESSAGE);
+        expect(error.responseData).toBeUndefined();
+      }
+    });
   });
 
   test("custom failure message retriever", async () => {

--- a/packages/http-client-base/README.md
+++ b/packages/http-client-base/README.md
@@ -9,6 +9,7 @@ Base implementation for [odata2ts](https://github.com/odata2ts/odata2ts) compati
 - implements standard error message retrieval method for OData error responses
   - works for V2 & V4
   - allows user to set custom retrieval method
+  - decodes the error document of a failed binary request, which arrives as a `Blob` or unparsed text
 - streamlines all HTTP calls (POST, GET, ...) into one method
 
 ## Installation

--- a/packages/http-client-base/src/ErrorResponseBody.ts
+++ b/packages/http-client-base/src/ErrorResponseBody.ts
@@ -1,0 +1,49 @@
+/**
+ * Makes the body of an error response readable for an {@link ErrorMessageRetriever}.
+ *
+ * A request's data type describes the *successful* response - bytes for a media resource, a stream for a
+ * large one. A failing request is answered with an OData error document all the same, so reading that
+ * document the way the successful payload would have been read buries the server's message in a `Blob`
+ * nobody ever looks into: every failure then comes out carrying the client's default message.
+ *
+ * Hence the body is decoded and parsed here instead. What is neither JSON nor decodable is handed back as
+ * it is - a caller may still make sense of it through a custom retriever, and an XML error document is at
+ * least readable as text.
+ *
+ * @param body the raw error response body as the client got hold of it
+ * @return the parsed error document, the plain text, or the body untouched
+ */
+export async function parseErrorResponseBody(body: unknown): Promise<unknown> {
+  const text = await asText(body);
+  if (text === undefined) {
+    return body;
+  }
+
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    // not JSON - an XML error document for instance
+    return trimmed;
+  }
+}
+
+/**
+ * The textual content of the body, or `undefined` if it is not the kind of thing that has one.
+ *
+ * Strings pass through: axios hands back an unparsed one whenever it was told to expect something other
+ * than JSON.
+ */
+async function asText(body: unknown): Promise<string | undefined> {
+  if (typeof body === "string") {
+    return body;
+  }
+  if (typeof Blob !== "undefined" && body instanceof Blob) {
+    return body.text();
+  }
+  return undefined;
+}

--- a/packages/http-client-base/src/index.ts
+++ b/packages/http-client-base/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./ErrorMessageRetriever";
+export * from "./ErrorResponseBody";
 export { BaseHttpClient, BaseRequestConfig } from "./BaseHttpClient";

--- a/packages/http-client-base/test/ErrorResponseBody.test.ts
+++ b/packages/http-client-base/test/ErrorResponseBody.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "vitest";
+import { parseErrorResponseBody, retrieveErrorMessage } from "../src";
+
+describe("parseErrorResponseBody Tests", function () {
+  const ERROR_DOCUMENT = { error: { message: "Not Found" } };
+
+  test("a Blob is decoded and parsed", async () => {
+    // what a failing binary request leaves behind, in every client
+    const result = await parseErrorResponseBody(new Blob([JSON.stringify(ERROR_DOCUMENT)]));
+
+    expect(result).toStrictEqual(ERROR_DOCUMENT);
+    expect(retrieveErrorMessage(result)).toBe("Not Found");
+  });
+
+  test("an unparsed string is parsed", async () => {
+    const result = await parseErrorResponseBody(JSON.stringify(ERROR_DOCUMENT));
+
+    expect(result).toStrictEqual(ERROR_DOCUMENT);
+  });
+
+  test("text which is not JSON is handed on as it is", async () => {
+    // an OData V2 server answers in XML unless asked otherwise, and a binary request cannot ask;
+    // parsing that is beyond this function, but the text is of more use to a caller than nothing
+    const xml = "<error><message>Requested entity could not be found.</message></error>";
+
+    expect(await parseErrorResponseBody(xml)).toBe(xml);
+    expect(await parseErrorResponseBody(new Blob([xml]))).toBe(xml);
+  });
+
+  test("surrounding whitespace does not decide the outcome", async () => {
+    expect(await parseErrorResponseBody(` \n${JSON.stringify(ERROR_DOCUMENT)}\n `)).toStrictEqual(ERROR_DOCUMENT);
+    expect(await parseErrorResponseBody("  xml  ")).toBe("xml");
+  });
+
+  test("an empty body yields nothing", async () => {
+    expect(await parseErrorResponseBody("")).toBeUndefined();
+    expect(await parseErrorResponseBody("   ")).toBeUndefined();
+    expect(await parseErrorResponseBody(new Blob([]))).toBeUndefined();
+  });
+
+  test("anything already parsed passes through untouched", async () => {
+    // the ordinary JSON request: the client handed over an object, and it must stay that object
+    expect(await parseErrorResponseBody(ERROR_DOCUMENT)).toBe(ERROR_DOCUMENT);
+    expect(await parseErrorResponseBody(undefined)).toBeUndefined();
+    expect(await parseErrorResponseBody(null)).toBeNull();
+  });
+});

--- a/packages/jquery/src/JQueryClient.ts
+++ b/packages/jquery/src/JQueryClient.ts
@@ -6,7 +6,7 @@ import {
   ODataHttpClientOptions,
   ODataHttpMethods,
 } from "@odata2ts/http-client-api";
-import { BaseHttpClient, BaseRequestConfig } from "@odata2ts/http-client-base";
+import { BaseHttpClient, BaseRequestConfig, parseErrorResponseBody } from "@odata2ts/http-client-base";
 import { JQueryClientError } from "./JQueryClientError";
 import { JQueryRequestConfig, mergeConfigs } from "./JQueryRequestConfig";
 
@@ -48,6 +48,31 @@ export class JQueryClient extends BaseHttpClient<JQueryRequestConfig> implements
         }
         return collector;
       }, {});
+  }
+
+  /**
+   * Turns a failed request into the error to reject with.
+   *
+   * `responseJSON` is jQuery's own parsing of the response and covers the ordinary case. It stays empty
+   * for a binary request though: with `responseType: "blob"` XmlHttpRequest offers neither `responseText`
+   * nor anything jQuery could have parsed, and the server's error document sits in `response` as binary.
+   * Reading it there is what keeps a failing `getBlob` from reporting the default message.
+   */
+  private async buildFailure(jqXHR: jqXHR, thrownError: string): Promise<JQueryClientError> {
+    let responseData: unknown;
+    try {
+      // `response` belongs to XmlHttpRequest itself, which jQuery's typing does not carry over
+      const rawResponse = (jqXHR as unknown as Partial<XMLHttpRequest> | undefined)?.response;
+      responseData = jqXHR?.responseJSON ?? (await parseErrorResponseBody(rawResponse));
+    } catch (e) {
+      responseData = undefined;
+    }
+
+    const responseMessage = this.retrieveErrorMessage(responseData);
+    const failMsg = responseMessage || thrownError || DEFAULT_ERROR_MESSAGE;
+    const errorMessage = responseMessage ? "OData server responded with error: " + responseMessage : failMsg;
+
+    return new JQueryClientError(errorMessage, jqXHR.status, this.mapHeaders(jqXHR), new Error(failMsg), jqXHR);
   }
 
   protected async executeRequest<ResponseModel>(
@@ -103,11 +128,8 @@ export class JQueryClient extends BaseHttpClient<JQueryRequestConfig> implements
           });
         },
         error: (jqXHR: JQuery.jqXHR, textStatus: string, thrownError: string) => {
-          const responseMessage = this.retrieveErrorMessage(jqXHR?.responseJSON);
-          const failMsg = responseMessage || thrownError || DEFAULT_ERROR_MESSAGE;
-          const errorMessage = responseMessage ? "OData server responded with error: " + responseMessage : failMsg;
-          const responseHeaders = this.mapHeaders(jqXHR);
-          reject(new JQueryClientError(errorMessage, jqXHR.status, responseHeaders, new Error(failMsg), jqXHR));
+          // decoding the error document may take a turn of the event loop, hence the detour
+          this.buildFailure(jqXHR, thrownError).then(reject, reject);
         },
       });
     });

--- a/packages/jquery/test/FailureHandling.test.ts
+++ b/packages/jquery/test/FailureHandling.test.ts
@@ -83,6 +83,47 @@ describe("JQueryClient Failure Handling Tests", function () {
     await expect(jqClient.get("")).rejects.toThrow(failMsg);
   });
 
+  /**
+   * A binary request is sent with `responseType: "blob"`, and XmlHttpRequest then offers neither
+   * `responseText` nor anything jQuery could have parsed into `responseJSON`. The server's error
+   * document sits in `response` as binary instead, where nobody looked - so every such failure came out
+   * with whatever jQuery had thrown, never with what the server said.
+   */
+  describe("error response to a binary request", () => {
+    function asBlob(body: object) {
+      return new Blob([JSON.stringify(body)]);
+    }
+
+    test("the error document is decoded from the binary response", async () => {
+      const failBodyMsg = "Testings!!!";
+      jqMock.errorResponse(400, asBlob(createFailureMsg(failBodyMsg)), RESPONSE_HEADERS, "Oh no!");
+
+      try {
+        await jqClient.getBlob(DEFAULT_URL);
+        expect.unreachable("the request should have failed");
+      } catch (e) {
+        const error = e as JQueryClientError;
+        expect(error.status).toBe(400);
+        expect(error.message).toContain(failBodyMsg);
+        expect(error.cause?.message).toBe(failBodyMsg);
+      }
+    });
+
+    test("v2 support included", async () => {
+      const failMsg = "Oh no!!!";
+      jqMock.errorResponse(400, asBlob(createFailureMsg(failMsg, true)), RESPONSE_HEADERS);
+
+      await expect(jqClient.getBlob(DEFAULT_URL)).rejects.toThrow(failMsg);
+    });
+
+    test("a body which is not an error document leaves jQuery's own message", async () => {
+      const failMsg = "Oh no!";
+      jqMock.errorResponse(400, new Blob(["not an error document"]), RESPONSE_HEADERS, failMsg);
+
+      await expect(jqClient.getBlob(DEFAULT_URL)).rejects.toThrow(failMsg);
+    });
+  });
+
   test("custom failure message retriever", async () => {
     const failMsg = "the failure";
 

--- a/packages/jquery/test/JQueryMock.ts
+++ b/packages/jquery/test/JQueryMock.ts
@@ -9,12 +9,16 @@ function createMockXhr(status: number, statusText: string, data: any, headers: {
         .map(([key, value]) => `${key.toLowerCase()}: ${value}\r\n`)
         .join("");
 
+  // A binary request leaves XmlHttpRequest with nothing to parse, so jQuery has no responseJSON to
+  // offer either - the body is only reachable as the raw `response`.
+  const isBinary = typeof Blob !== "undefined" && data instanceof Blob;
+
   return {
     status,
     statusText,
     getResponseHeader: (name: string) => (headers ? headers[name] : undefined),
     getAllResponseHeaders: () => respHeaders,
-    responseJSON: data,
+    ...(isBinary ? { response: data } : { responseJSON: data }),
   };
 }
 


### PR DESCRIPTION
- an error response is no longer read the way the *successful* payload would have been read — `getBlob` handed the OData error document to the blob reader, `getStream` passed the unread stream on, axios applied its `responseType` to it, and jQuery found no `responseJSON` at all, since XmlHttpRequest parses nothing when it expects binary
- `parseErrorResponseBody` in `http-client-base` decodes a `Blob` resp. parses an unparsed string, so `ErrorMessageRetriever` — the standard one as well as a custom one — has something to read
- `FetchClient` reads a failed response as text regardless of the request's data type; `AxiosClient` and `JQueryClient` decode what their transport left them with
- a body which is neither JSON nor decodable is passed on as it is: an OData V2 server answers in XML unless asked otherwise, and a binary request cannot ask, so the message stays the fallback there — but the document reaches the caller instead of being lost in a `Blob`
- tests for all three clients and the new helper; each of the nine new ones fails without the fix

Verified end to end against the reference servers of the odata2ts integration tests, with this branch's build linked in: a 404 on a media resource of the CAP server now reports `Not Found` instead of `No error message!`, the Olingo 2 server keeps the fallback because its error body is XML, and the ASP.NET suite is unaffected.

Follow-up in the odata2ts repo once this is released: `int-test/cap/test/v2/feature/Blobs.test.ts` and `int-test/olingo-v2/test/feature/Blobs.test.ts` pin the fallback message today and can then assert what the server actually said.
