### PR TITLE
build: declare tool binaries in every workspace that invokes them

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,6 +24,8 @@ jobs:
 #        run: corepack enable && yarn set version 3.5.0 && yarn install --immutable
       - name: Install packages
         run: yarn --immutable
+      - name: Check dependency consistency
+        run: yarn constraints
       - name: Build
         run: yarn build
       - name: Check Circular Deps

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@types/jsdom": "^28.0.3",
     "@types/node": "^24",
     "@vitest/coverage-istanbul": "^4.1.10",
+    "@yarnpkg/types": "^4.0.1",
     "env-cmd": "^11.0.0",
     "jsdom": "^29.1.1",
     "madge": "^8.0.0",

--- a/packages/axios/package.json
+++ b/packages/axios/package.json
@@ -37,8 +37,10 @@
   "devDependencies": {
     "@types/node": "^24",
     "axios": "^1.18.1",
+    "madge": "^8.0.0",
     "rimraf": "^6.1.3",
-    "typescript": "6.0.3"
+    "typescript": "6.0.3",
+    "vitest": "^4.1.10"
   },
   "peerDependencies": {
     "axios": "^0.27.0 || ^1.0.0"

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -36,8 +36,10 @@
   "devDependencies": {
     "@odata2ts/odata-core": "^0.3.7",
     "@types/node": "^24",
+    "madge": "^8.0.0",
     "rimraf": "^6.1.3",
-    "typescript": "6.0.3"
+    "typescript": "6.0.3",
+    "vitest": "^4.1.10"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/http-client-api/package.json
+++ b/packages/http-client-api/package.json
@@ -33,8 +33,10 @@
   },
   "devDependencies": {
     "@types/node": "^24",
+    "madge": "^8.0.0",
     "rimraf": "^6.1.3",
-    "typescript": "6.0.3"
+    "typescript": "6.0.3",
+    "vitest": "^4.1.10"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/http-client-base/package.json
+++ b/packages/http-client-base/package.json
@@ -33,8 +33,10 @@
   "devDependencies": {
     "@odata2ts/odata-core": "^0.3.7",
     "@types/node": "^24",
+    "madge": "^8.0.0",
     "rimraf": "^6.1.3",
-    "typescript": "6.0.3"
+    "typescript": "6.0.3",
+    "vitest": "^4.1.10"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jquery/package.json
+++ b/packages/jquery/package.json
@@ -38,8 +38,10 @@
     "@types/jquery": "^3.5.34",
     "@types/node": "^24",
     "jquery": "~3.6.4",
+    "madge": "^8.0.0",
     "rimraf": "^6.1.3",
-    "typescript": "6.0.3"
+    "typescript": "6.0.3",
+    "vitest": "^4.1.10"
   },
   "peerDependencies": {
     "jquery": ">1.0"

--- a/yarn.config.cjs
+++ b/yarn.config.cjs
@@ -1,0 +1,34 @@
+/**
+ * Yarn constraints: the root package.json is the single source of truth for dependency versions.
+ *
+ * Every workspace has to declare the tools its own scripts invoke — Yarn only exposes the binaries of
+ * dependencies a workspace declares itself (it does not fall back to the root's node_modules/.bin).
+ * That would invite version drift across a dozen package.json files, so this constraint pins every
+ * duplicated range back to whatever the root declares.
+ *
+ * Check: `yarn constraints` (also runs in CI) — fix: `yarn constraints --fix`.
+ */
+
+/** @type {import('@yarnpkg/types').Yarn.Config} */
+module.exports = {
+  constraints({ Yarn }) {
+    const root = Yarn.workspace({ cwd: "." });
+
+    // peerDependencies are excluded on purpose: they express what a consumer has to bring along
+    // (e.g. `jquery: ">1.0"`), not what this repo installs. The jquery devDependency stays pinned to
+    // 3.6.x for UI5 compatibility and has no root counterpart, so it is untouched either way.
+    for (const dependency of [
+      ...Yarn.dependencies({ type: "dependencies" }),
+      ...Yarn.dependencies({ type: "devDependencies" }),
+    ]) {
+      if (dependency.workspace.cwd === root.cwd) continue;
+      // workspace:^ links resolve locally and have no root counterpart
+      if (dependency.range.startsWith("workspace:")) continue;
+
+      const rootDependency = Yarn.dependency({ workspace: root, ident: dependency.ident });
+      if (rootDependency) {
+        dependency.update(rootDependency.range);
+      }
+    }
+  },
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -522,9 +522,11 @@ __metadata:
   resolution: "@odata2ts/http-client-api@workspace:packages/http-client-api"
   dependencies:
     "@types/node": "npm:^24"
+    madge: "npm:^8.0.0"
     rimraf: "npm:^6.1.3"
     tslib: "npm:^2.8.1"
     typescript: "npm:6.0.3"
+    vitest: "npm:^4.1.10"
   languageName: unknown
   linkType: soft
 
@@ -535,9 +537,11 @@ __metadata:
     "@odata2ts/http-client-base": "npm:^0.5.8"
     "@types/node": "npm:^24"
     axios: "npm:^1.18.1"
+    madge: "npm:^8.0.0"
     rimraf: "npm:^6.1.3"
     tslib: "npm:^2.8.1"
     typescript: "npm:6.0.3"
+    vitest: "npm:^4.1.10"
   peerDependencies:
     axios: ^0.27.0 || ^1.0.0
   languageName: unknown
@@ -550,9 +554,11 @@ __metadata:
     "@odata2ts/http-client-api": "npm:^0.6.7"
     "@odata2ts/odata-core": "npm:^0.3.7"
     "@types/node": "npm:^24"
+    madge: "npm:^8.0.0"
     rimraf: "npm:^6.1.3"
     tslib: "npm:^2.8.1"
     typescript: "npm:6.0.3"
+    vitest: "npm:^4.1.10"
   languageName: unknown
   linkType: soft
 
@@ -563,9 +569,11 @@ __metadata:
     "@odata2ts/http-client-base": "npm:^0.5.8"
     "@odata2ts/odata-core": "npm:^0.3.7"
     "@types/node": "npm:^24"
+    madge: "npm:^8.0.0"
     rimraf: "npm:^6.1.3"
     tslib: "npm:^2.8.1"
     typescript: "npm:6.0.3"
+    vitest: "npm:^4.1.10"
   languageName: unknown
   linkType: soft
 
@@ -577,9 +585,11 @@ __metadata:
     "@types/jquery": "npm:^3.5.34"
     "@types/node": "npm:^24"
     jquery: "npm:~3.6.4"
+    madge: "npm:^8.0.0"
     rimraf: "npm:^6.1.3"
     tslib: "npm:^2.8.1"
     typescript: "npm:6.0.3"
+    vitest: "npm:^4.1.10"
   peerDependencies:
     jquery: ">1.0"
   languageName: unknown
@@ -594,6 +604,7 @@ __metadata:
     "@types/jsdom": "npm:^28.0.3"
     "@types/node": "npm:^24"
     "@vitest/coverage-istanbul": "npm:^4.1.10"
+    "@yarnpkg/types": "npm:^4.0.1"
     env-cmd: "npm:^11.0.0"
     jsdom: "npm:^29.1.1"
     madge: "npm:^8.0.0"
@@ -1104,6 +1115,15 @@ __metadata:
   dependencies:
     chevrotain: "npm:7.1.1"
   checksum: 10/df1aa7ac0ec81ec6363b515f4bb80043c8c29c2e2c87ba668f142d20090f8a67ae1bde3665ee63ebbca12dd9d77991795d97f02fa0e2e64c20ba7a0636209463
+  languageName: node
+  linkType: hard
+
+"@yarnpkg/types@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "@yarnpkg/types@npm:4.0.1"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10/f391763cd955356e9aad551b29e8de7bbf68a6c8992af7cdc950ccf53f8aff6695ad81aa4c8a8e7c582786a840a4f30617732e2cb49f4109b971a9242c31c9fc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Yarn only exposes the binaries of dependencies a workspace declares itself — there is no fallback to the root's `node_modules/.bin`. Running a script from within a package therefore failed with `command not found: vitest` / `command not found: madge`, while the same script via a root script worked, because the root passes its shim directory down through `PATH`.
- `rimraf` and `typescript` were already declared everywhere; `madge` and `vitest` are now declared in each of the five packages as well.
- Added `yarn.config.cjs` so the root `package.json` stays the single source of truth for versions: every `dependency`/`devDependency` of a workspace is pinned back to the root's range, `peerDependencies` deliberately excluded. The `jquery` devDependency stays on 3.6.x for UI5 compatibility and has no root counterpart, so the constraint leaves it alone.
- `yarn constraints` runs in CI ahead of the build; verified it exits 1 on drift and 0 on parity.
- Verified all 15 `build` / `test` / `check-circular-deps` invocations across the five packages now succeed individually, and the root `build`, `test`, `coverage` (183 tests) and `check-circular-deps` runs are unchanged.
- Mirrors odata2ts/converter#50.