### PR TITLE
chore: remove vitest.workspace.ts, which vitest 4 ignores

### DIFF
--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -1,3 +1,0 @@
-import { defineWorkspace } from "vitest/config";
-
-export default defineWorkspace(["packages/*"]);


### PR DESCRIPTION
- Vitest 4 dropped the workspace concept, so `vitest.workspace.ts` has had no effect for a while — what the root run executes is decided by `vite.config.ts` alone.
- That it was dead is visible in the run itself: the root picks up every `packages/*/int-test/**.test.ts` too, which a working workspace definition listing only `packages/*` projects would have separated.
- Deliberately behaviour-neutral: no `include`/`exclude` added, so the same set keeps running. Verified identical before and after — 20 test files, 183 tests, for both `vitest run` and `yarn coverage`.