### PR TITLE
build: declare jsdom in the jquery package, drop unused @types/jsdom

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   "devDependencies": {
     "@ianvs/prettier-plugin-sort-imports": "^4.7.1",
     "@prettier/plugin-xml": "^3.4.2",
-    "@types/jsdom": "^28.0.3",
     "@types/node": "^24",
     "@vitest/coverage-istanbul": "^4.1.10",
     "@yarnpkg/types": "^4.0.1",

--- a/packages/jquery/package.json
+++ b/packages/jquery/package.json
@@ -38,6 +38,7 @@
     "@types/jquery": "^3.5.34",
     "@types/node": "^24",
     "jquery": "~3.6.4",
+    "jsdom": "^29.1.1",
     "madge": "^8.0.0",
     "rimraf": "^6.1.3",
     "typescript": "6.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -585,6 +585,7 @@ __metadata:
     "@types/jquery": "npm:^3.5.34"
     "@types/node": "npm:^24"
     jquery: "npm:~3.6.4"
+    jsdom: "npm:^29.1.1"
     madge: "npm:^8.0.0"
     rimraf: "npm:^6.1.3"
     tslib: "npm:^2.8.1"
@@ -601,7 +602,6 @@ __metadata:
   dependencies:
     "@ianvs/prettier-plugin-sort-imports": "npm:^4.7.1"
     "@prettier/plugin-xml": "npm:^3.4.2"
-    "@types/jsdom": "npm:^28.0.3"
     "@types/node": "npm:^24"
     "@vitest/coverage-istanbul": "npm:^4.1.10"
     "@yarnpkg/types": "npm:^4.0.1"
@@ -850,27 +850,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/jsdom@npm:^28.0.3":
-  version: 28.0.3
-  resolution: "@types/jsdom@npm:28.0.3"
-  dependencies:
-    "@types/node": "npm:*"
-    "@types/tough-cookie": "npm:*"
-    parse5: "npm:^8.0.0"
-    undici-types: "npm:^7.21.0"
-  checksum: 10/a98a86449245372a1c02fee45299bef8eae9bdebe22863e02f785f05fd1f27c51c381aefe72054247994612f94ee0f45520a6eaa32c5d91d36639d208b578e87
-  languageName: node
-  linkType: hard
-
-"@types/node@npm:*":
-  version: 22.5.0
-  resolution: "@types/node@npm:22.5.0"
-  dependencies:
-    undici-types: "npm:~6.19.2"
-  checksum: 10/89af3bd217b1559b645a9ed16d4ae3add75749814cbd8eefddd1b96003d1973afb1c8a2b23d69f3a8cc6c532e3aa185eaf5cc29a6e7c42c311a2aad4c99430ae
-  languageName: node
-  linkType: hard
-
 "@types/node@npm:^24":
   version: 24.13.3
   resolution: "@types/node@npm:24.13.3"
@@ -884,13 +863,6 @@ __metadata:
   version: 2.3.8
   resolution: "@types/sizzle@npm:2.3.8"
   checksum: 10/2ac62443dc917f5f903cbd9afc51c7d6cc1c6569b4e1a15faf04aea5b13b486e7f208650014c3dc4fed34653eded3e00fe5abffe0e6300cbf0e8a01beebf11a6
-  languageName: node
-  linkType: hard
-
-"@types/tough-cookie@npm:*":
-  version: 4.0.5
-  resolution: "@types/tough-cookie@npm:4.0.5"
-  checksum: 10/01fd82efc8202670865928629697b62fe9bf0c0dcbc5b1c115831caeb073a2c0abb871ff393d7df1ae94ea41e256cb87d2a5a91fd03cdb1b0b4384e08d4ee482
   languageName: node
   linkType: hard
 
@@ -3104,7 +3076,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"parse5@npm:^8.0.0, parse5@npm:^8.0.1":
+"parse5@npm:^8.0.1":
   version: 8.0.1
   resolution: "parse5@npm:8.0.1"
   dependencies:
@@ -3951,20 +3923,6 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 10/696e1b017bc2635f4e0c94eb4435357701008e2f272f553d06e35b494b8ddc60aa221145e286c28ace0c89ee32827a28c2040e3a69bdc108b1a5dc8fb40b72e3
-  languageName: node
-  linkType: hard
-
-"undici-types@npm:^7.21.0":
-  version: 7.29.0
-  resolution: "undici-types@npm:7.29.0"
-  checksum: 10/da70d58dbd44ad79771c1bba6e311c790bd7e663c42f66fa7b793822f8f3fe238b91f1448e60ee9079ba9237ad92575681a35707e0e60562c902debdabc51824
-  languageName: node
-  linkType: hard
-
-"undici-types@npm:~6.19.2":
-  version: 6.19.8
-  resolution: "undici-types@npm:6.19.8"
-  checksum: 10/cf0b48ed4fc99baf56584afa91aaffa5010c268b8842f62e02f752df209e3dea138b372a60a963b3b2576ed932f32329ce7ddb9cb5f27a6c83040d8cd74b7a70
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- `jsdom` is declared in `packages/jquery/package.json`, the only package that uses it (`// @vitest-environment jsdom` in `test/BlobHandling.test.ts` and `int-test/HttpCommunication.test.ts`); until now `yarn workspace @odata2ts/http-client-jquery run test` only resolved it via hoisting
- the root declaration stays, both as the version source of truth for `yarn.config.cjs` and because the root coverage run executes those same test files
- `@types/jsdom` removed: no file imports `jsdom`, and `tsconfig.settings.json` sets `types: ["node"]`, so it was never auto-included — the DOM globals come from `lib: ["esnext", "dom"]`. It had also drifted to v28 against jsdom v29
- verified with `tsc -p tsconfig.test.json`, `yarn unit-test` in `packages/jquery`, and a root-level `vitest run packages/jquery/test`